### PR TITLE
feat: implements eip712 in TAP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,19 @@ license = "Apache-2.0"
 [dependencies]
 
 primitive-types={version="0.12.1", features=["serde"]}
-k256={version="0.12.0", features=["ecdsa", "serde"]}
+k256={version="0.13.0", features=["ecdsa", "serde"]}
 rand_core="0.6.4"
 serde={ version="1.0", features=["derive"] }
 rand="0.8.5"
 thiserror="1.0.38"
 ethereum-types={version="0.14.1"}
 rstest = "0.16.0"
+ethers = "2.0.0"
+ethers-derive-eip712 = "2.0.0"
+ethers-core = "2.0.0"
+ethers-contract = "2.0.0"
+criterion = "0.4.0"
+
+[[bench]]
+name = 'timeline_aggretion_protocol_benchmark'
+harness = false

--- a/benches/timeline_aggretion_protocol_benchmark.rs
+++ b/benches/timeline_aggretion_protocol_benchmark.rs
@@ -1,0 +1,95 @@
+// Copyright 2023-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Module containing Receipt type used for providing and verifying a payment
+//!
+//! Receipts are used as single transaction promise of payment. A payment sender
+//! creates a receipt and ECDSA signs it, then sends it to a payment receiver.
+//! The payment receiver would verify the received receipt and store it to be
+//! accumulated with other received receipts in the future.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ethereum_types::Address;
+use k256::ecdsa::{SigningKey, VerifyingKey};
+use rand_core::OsRng;
+use std::str::FromStr;
+use timeline_aggregation_protocol::{
+    eip_712_signed_message::EIP712SignedMessage, receipt::Receipt,
+    receipt_aggregate_voucher::ReceiptAggregateVoucher,
+};
+
+pub fn create_and_sign_receipt(
+    allocation_id: Address,
+    timestamp_ns: u64,
+    value: u128,
+    signing_key: &SigningKey,
+) -> EIP712SignedMessage<Receipt> {
+    EIP712SignedMessage::new(
+        Receipt::new(allocation_id, timestamp_ns, value),
+        signing_key,
+    )
+    .unwrap()
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let signing_key = SigningKey::random(&mut OsRng);
+    let verifying_key = VerifyingKey::from(&signing_key);
+
+    // Arbitrary values wrapped in black box to avoid compiler optimizing them out
+    let allocation_id =
+        black_box(Address::from_str("0xabababababababababababababababababababab").unwrap());
+    let value = black_box(12345u128);
+    let timestamp_ns = black_box(12345u64);
+
+    c.bench_function("Create Receipt", |b| {
+        b.iter(|| create_and_sign_receipt(allocation_id, timestamp_ns, value, &signing_key))
+    });
+
+    let receipt = black_box(create_and_sign_receipt(
+        allocation_id,
+        timestamp_ns,
+        value,
+        &signing_key,
+    ));
+
+    c.bench_function("Validate Receipt", |b| {
+        b.iter(|| receipt.check_signature(verifying_key))
+    });
+
+    let mut rav_group = c.benchmark_group("Create RAV with varying input sizes");
+
+    for log_number_of_receipts in 10..30 {
+        let receipts = black_box(
+            (0..2 ^ log_number_of_receipts)
+                .map(|_| {
+                    EIP712SignedMessage::new(
+                        Receipt::new(allocation_id, timestamp_ns, value),
+                        &signing_key,
+                    )
+                    .unwrap()
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        rav_group.bench_function(
+            &format!("Create RAV w/ 2^{} receipt's", log_number_of_receipts),
+            |b| {
+                b.iter(|| {
+                    ReceiptAggregateVoucher::aggregate_receipts(allocation_id, &receipts, None)
+                })
+            },
+        );
+        let signed_rav = black_box(EIP712SignedMessage::new(
+            ReceiptAggregateVoucher::aggregate_receipts(allocation_id, &receipts, None).unwrap(),
+            &signing_key,
+        ))
+        .unwrap();
+        rav_group.bench_function(
+            &format!("Validate RAV w/ 2^{} receipt's", log_number_of_receipts),
+            |b| b.iter(|| signed_rav.check_signature(verifying_key)),
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/eip_712_signed_message.rs
+++ b/src/eip_712_signed_message.rs
@@ -1,0 +1,51 @@
+// Copyright 2023-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Module containing EIP712 message and signature
+//!
+
+use crate::{Error, Result};
+use ethers_core::types::transaction::eip712;
+use k256::ecdsa::{signature::Signer, signature::Verifier, Signature, SigningKey, VerifyingKey};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EIP712SignedMessage<M: eip712::Eip712> {
+    /// Message to be signed
+    pub message: M,
+    /// ECDSA Signature of eip712 hash of message
+    pub signature: Signature,
+}
+
+impl<M: eip712::Eip712> EIP712SignedMessage<M> {
+    /// creates signed message with signed EIP712 hash of `message` using `signing_key`
+    pub fn new(message: M, signing_key: &SigningKey) -> Result<Self> {
+        let encoded_message = Self::get_eip712_encoding(&message)?;
+
+        Ok(Self {
+            message,
+            signature: signing_key.sign(&encoded_message),
+        })
+    }
+
+    /// Checks that receipts signature is valid for given verifying key, returns `Ok` if it is valid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSignature`] if the signature is not valid with provided `verifying_key`
+    ///
+    pub fn check_signature(&self, verifying_key: VerifyingKey) -> Result<()> {
+        verifying_key.verify(&Self::get_eip712_encoding(&self.message)?, &self.signature)?;
+        Ok(())
+    }
+
+    /// Unable to cleanly typecast encode_eip712 associated error type to crate
+    /// error type, so abstract away the error translating to this function
+    fn get_eip712_encoding(message: &M) -> Result<[u8; 32]> {
+        message
+            .encode_eip712()
+            .map_err(|e| Error::EIP712EncodeError {
+                source_error_message: e.to_string().clone(),
+            })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,17 +9,18 @@
 use ethereum_types::Address;
 use thiserror::Error;
 
+pub mod eip_712_signed_message;
 pub mod receipt;
 pub mod receipt_aggregate_voucher;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("invalid allocation ID: {received_allocation_id} (valid  {expected_allocation_ids})")]
+    #[error("invalid allocation ID: {received_allocation_id} (valid {expected_allocation_ids})")]
     InvalidAllocationID {
         received_allocation_id: Address,
         expected_allocation_ids: String,
     },
-    #[error("invalid signature on Receipt Aggregate Voucher")]
+    #[error(transparent)]
     InvalidSignature(#[from] k256::ecdsa::Error),
     #[error("invalid timestamp: {received_timestamp} (expected range [{timestamp_min}, {timestamp_max}) )")]
     InvalidTimestamp {
@@ -34,12 +35,17 @@ pub enum Error {
     },
     #[error("Aggregating receipt results in overflow")]
     AggregateOverflow,
+    #[error("Failed to encode to EIP712 hash:\n{source_error_message}")]
+    EIP712EncodeError { source_error_message: String },
 }
 type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(test)]
-mod tests {
-    use crate::{receipt::Receipt, receipt_aggregate_voucher::ReceiptAggregateVoucher, Error};
+mod tap_tests {
+    use crate::{
+        eip_712_signed_message::EIP712SignedMessage, receipt::Receipt,
+        receipt_aggregate_voucher::ReceiptAggregateVoucher,
+    };
     use ethereum_types::Address;
     use k256::ecdsa::{SigningKey, VerifyingKey};
     use rand_core::OsRng;
@@ -64,41 +70,26 @@ mod tests {
     }
 
     #[rstest]
-    #[case::basic_receipt_test(30, 20, 40, 100)]
-    #[case::closest_valid_min_timestamp(30, 30, 40, 100)]
-    #[case::closest_valid_max_timestamp(30, 20, 31, 100)]
-    #[case::closest_valid_min_max_timestamp(30, 30, 31, 100)]
-    #[case::timestamp_at_min(u64::MIN, u64::MIN, 31, 100)]
-    #[case::timestamp_at_max(u64::MAX-1, u64::MAX-1, u64::MAX, 100)]
-    #[case::min_value_amount(30, 20, 40, u128::MIN)]
-    #[case::min_value_amount(30, 20, 40, u128::MAX)]
-
-    fn receipt_is_valid(
+    #[case::basic_receipt_test(30, 100)]
+    #[case::closest_valid_min_timestamp(30, 100)]
+    #[case::closest_valid_max_timestamp(30, 100)]
+    #[case::closest_valid_min_max_timestamp(30, 100)]
+    fn signed_receipt_is_valid(
         keys: (SigningKey, VerifyingKey),
         allocation_ids: Vec<Address>,
         #[case] timestamp: u64,
-        #[case] timestamp_min: u64,
-        #[case] timestamp_max: u64,
         #[case] value: u128,
     ) {
-        let test_receipt = Receipt::new(allocation_ids[0], timestamp, value, &keys.0);
-
-        assert!(test_receipt
-            .is_valid(
-                keys.1,
-                &[allocation_ids[0]],
-                timestamp_min,
-                timestamp_max,
-                None
-            )
-            .is_ok())
+        let test_receipt = Receipt::new(allocation_ids[0], timestamp, value);
+        let signed_message = EIP712SignedMessage::new(test_receipt, &keys.0).unwrap();
+        assert!(signed_message.check_signature(keys.1).is_ok())
     }
 
     #[rstest]
     #[case::basic_rav_test(vec![1,2,3,4], vec![45,56,34,23])]
     #[case::rav_from_zero_valued_receipts(vec![1,2,3,4], vec![0,0,0,0])]
     #[case::rav_with_same_timestamped_receipts(vec![1,1,1,1], vec![45,56,34,23])]
-    fn rav_is_valid_with_no_previous_rav(
+    fn signed_rav_is_valid_with_no_previous_rav(
         keys: (SigningKey, VerifyingKey),
         allocation_ids: Vec<Address>,
         #[case] timestamps: Vec<u64>,
@@ -107,19 +98,28 @@ mod tests {
         // Create receipts
         let mut receipts = Vec::new();
         for (value, timestamp) in values.iter().zip(timestamps) {
-            receipts.push(Receipt::new(allocation_ids[0], timestamp, *value, &keys.0))
+            receipts.push(
+                EIP712SignedMessage::new(
+                    crate::receipt::Receipt::new(allocation_ids[0], timestamp, *value),
+                    &keys.0,
+                )
+                .unwrap(),
+            );
         }
 
-        let rav =
-            ReceiptAggregateVoucher::aggregate_receipt(&receipts, keys.1, &keys.0, None).unwrap();
-        assert!(rav.is_valid(keys.1, allocation_ids[0]).is_ok());
+        // Skipping receipts validation in this test, aggregate_receipts assumes receipts are valid.
+
+        let rav = ReceiptAggregateVoucher::aggregate_receipts(allocation_ids[0], &receipts, None)
+            .unwrap();
+        let signed_rav = EIP712SignedMessage::new(rav, &keys.0).unwrap();
+        assert!(signed_rav.check_signature(keys.1).is_ok());
     }
 
     #[rstest]
     #[case::basic_rav_test(vec![1,2,3,4], vec![45,56,34,23])]
     #[case::rav_from_zero_valued_receipts(vec![1,2,3,4], vec![0,0,0,0])]
     #[case::rav_with_same_timestamped_receipts(vec![1,1,2,2], vec![45,56,34,23])]
-    fn rav_is_valid_with_previous_rav(
+    fn signed_rav_is_valid_with_previous_rav(
         keys: (SigningKey, VerifyingKey),
         allocation_ids: Vec<Address>,
         #[case] timestamps: Vec<u64>,
@@ -128,51 +128,33 @@ mod tests {
         // Create receipts
         let mut receipts = Vec::new();
         for (value, timestamp) in values.iter().zip(timestamps) {
-            receipts.push(Receipt::new(allocation_ids[0], timestamp, *value, &keys.0))
+            receipts.push(
+                EIP712SignedMessage::new(
+                    crate::receipt::Receipt::new(allocation_ids[0], timestamp, *value),
+                    &keys.0,
+                )
+                .unwrap(),
+            );
         }
 
         // Create previous RAV from first half of receipts
-        let prev_rav = ReceiptAggregateVoucher::aggregate_receipt(
+        let prev_rav = ReceiptAggregateVoucher::aggregate_receipts(
+            allocation_ids[0],
             &receipts[0..receipts.len() / 2],
-            keys.1,
-            &keys.0,
             None,
         )
         .unwrap();
+        let signed_prev_rav = EIP712SignedMessage::new(prev_rav, &keys.0).unwrap();
 
         // Create new RAV from last half of receipts and prev_rav
-        let rav = ReceiptAggregateVoucher::aggregate_receipt(
+        let rav = ReceiptAggregateVoucher::aggregate_receipts(
+            allocation_ids[0],
             &receipts[receipts.len() / 2..receipts.len()],
-            keys.1,
-            &keys.0,
-            Some(prev_rav),
+            Some(signed_prev_rav),
         )
         .unwrap();
-        assert!(rav.is_valid(keys.1, allocation_ids[0]).is_ok());
-    }
+        let signed_rav = EIP712SignedMessage::new(rav, &keys.0).unwrap();
 
-    #[rstest]
-    #[case::basic_rav_test(vec![1,2,3,4], vec![45,56,34,23])]
-    #[case::rav_from_zero_valued_receipts(vec![1,2,3,4], vec![0,0,0,0])]
-    #[case::rav_with_same_timestamped_receipts(vec![1,1,1,1], vec![45,56,34,23])]
-    fn rav_with_invalid_receipt_allocation_id_submitted_errors(
-        keys: (SigningKey, VerifyingKey),
-        allocation_ids: Vec<Address>,
-        #[case] timestamps: Vec<u64>,
-        #[case] values: Vec<u128>,
-    ) {
-        // Create receipts
-        let mut receipts = Vec::new();
-        for (value, timestamp) in values.iter().zip(timestamps) {
-            receipts.push(Receipt::new(allocation_ids[0], timestamp, *value, &keys.0))
-        }
-
-        // Inject receipt with invalid allocation id
-        receipts.last_mut().unwrap().allocation_id = allocation_ids[1];
-
-        let false_rav =
-            ReceiptAggregateVoucher::aggregate_receipt(&receipts, keys.1, &keys.0, None)
-                .unwrap_err();
-        assert!(matches!(false_rav, Error::InvalidAllocationID { .. }));
+        assert!(signed_rav.check_signature(keys.1).is_ok());
     }
 }

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -9,13 +9,21 @@
 //! accumulated with other received receipts in the future.
 
 use ethereum_types::Address;
-use k256::ecdsa::{signature::Signer, signature::Verifier, Signature, SigningKey, VerifyingKey};
-
-use crate::{Error, Result};
+use ethers_contract::EthAbiType;
+use ethers_core::types::transaction::eip712::Eip712;
+use ethers_derive_eip712::*;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
+
 /// Holds information needed for promise of payment signed with ECDSA
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Eip712, EthAbiType)]
+#[eip712(
+    //TODO: Update this info, or make it user defined?
+    name = "tap",
+    version = "1",
+    chain_id = 1,
+    verifying_contract = "0x0000000000000000000000000000000000000000"
+)]
 pub struct Receipt {
     /// Unique allocation id this receipt belongs to
     pub allocation_id: Address,
@@ -25,113 +33,17 @@ pub struct Receipt {
     pub nonce: u64,
     /// GRT value for transaction (truncate to lower bits)
     pub value: u128,
-    /// ECDSA Signature of all other values in receipt
-    pub signature: Signature,
 }
 
 impl Receipt {
     /// Returns a receipt with provided values signed with `signing_key`
-    pub fn new(
-        allocation_id: Address,
-        timestamp_ns: u64,
-        value: u128,
-        signing_key: &SigningKey,
-    ) -> Receipt {
-        // TODO: Should we generate timestamp in library?
+    pub fn new(allocation_id: Address, timestamp_ns: u64, value: u128) -> Self {
         let nonce = thread_rng().gen::<u64>();
-        Receipt {
+        Self {
             allocation_id,
             timestamp_ns,
-            nonce, // Decide what RNG should be used (prioritize cheap compute)
+            nonce,
             value,
-            signature: signing_key.sign(&Self::get_message_bytes(
-                allocation_id,
-                timestamp_ns,
-                nonce,
-                value,
-            )),
         }
-    }
-    /// Verifies given values match values on receipt and that receipts signature is valid for given verifying key, returns `Ok` if valid or an `Error` indicate what was found to be invalid.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::InvalidAllocationID`] if the allocation ID on the receipt does not exist in provided `allocation_ids`
-    ///
-    /// Returns [`Error::InvalidTimestamp`] if the receipt timestamp is not within the half-open range [`timestamp_min`, `timestamp_max`)
-    ///
-    /// Returns [`Error::InvalidValue`] if `Some` `expected_value` is provided but does not match receipts value
-    ///
-    /// Returns [`Error::InvalidSignature`] if the signature is not valid with provided `verifying_key`
-    ///
-    pub fn is_valid(
-        &self,
-        verifying_key: VerifyingKey, //TODO: with multiple gateway operators how is this value known
-        allocation_ids: &[Address],
-        timestamp_min: u64,
-        timestamp_max: u64,
-        expected_value: Option<u128>,
-    ) -> Result<()> {
-        // TODO: update to return the public key found with ECRECOVER
-        let timestamp_range = timestamp_min..timestamp_max;
-        if !allocation_ids.contains(&self.allocation_id) {
-            return Err(Error::InvalidAllocationID {
-                received_allocation_id: self.allocation_id,
-                expected_allocation_ids: format!("{:?}", allocation_ids),
-            });
-        }
-        if !timestamp_range.contains(&self.timestamp_ns) {
-            return Err(Error::InvalidTimestamp {
-                received_timestamp: self.timestamp_ns,
-                timestamp_min,
-                timestamp_max,
-            });
-        }
-        if let Some(expected_val) = expected_value {
-            if expected_val != self.value {
-                return Err(Error::InvalidValue {
-                    received_value: self.value,
-                    expected_value: expected_val,
-                });
-            }
-        }
-        self.is_valid_signature(verifying_key)
-    }
-
-    /// Checks that receipts signature is valid for given verifying key, returns `Ok` if it is valid.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::InvalidSignature`] if the signature is not valid with provided `verifying_key`
-    ///
-    pub fn is_valid_signature(&self, verifying_key: VerifyingKey) -> Result<()> {
-        verifying_key.verify(
-            &Self::get_message_bytes(
-                self.allocation_id,
-                self.timestamp_ns,
-                self.nonce,
-                self.value,
-            ),
-            &self.signature,
-        )?;
-        Ok(())
-    }
-
-    /// Creates a byte vector of the receipts message for signing
-    ///
-    fn get_message_bytes(
-        allocation_id: Address,
-        timestamp_ns: u64,
-        nonce: u64,
-        value: u128,
-    ) -> Vec<u8> {
-        allocation_id
-            .as_bytes()
-            .iter()
-            .copied()
-            .chain(timestamp_ns.to_be_bytes())
-            .chain(nonce.to_be_bytes())
-            .chain(value.to_be_bytes())
-            .collect()
     }
 }


### PR DESCRIPTION
Adds eip712 implementation to RAV and receipts as well as adding a generic eip712 signed message class

BREAKING CHANGE: RAV and receipt api have changed and all checks/verify have been removed from the implementation