### PR TITLE
ci: refactor rust tests action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,4 +48,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
            rustup component add clippy
-           cargo clippy --all-features
+           cargo clippy --all-features -- -D clippy::all


### PR DESCRIPTION
Removed action dependency to run cargo directly from the latest rust image:  https://hub.docker.com/_/rust/tags