### PR TITLE
Fix warning code values

### DIFF
--- a/tap_aggregator/README.md
+++ b/tap_aggregator/README.md
@@ -51,7 +51,7 @@ Warning object format (similar to the standard JSON-RPC error object):
 
 We define these warning codes:
 
-- `-32101` API version deprecation
+- `-32051` API version deprecation
   
   Also returns an object containing the method's supported versions in the `data` field. Example:
 
@@ -63,7 +63,7 @@ We define these warning codes:
           "data": {...},
           "warnings": [
               {
-                  "code": -32101,
+                  "code": -32051,
                   "data": {
                       "versions_deprecated": [
                           "0.0"

--- a/tap_aggregator/src/error_codes.rs
+++ b/tap_aggregator/src/error_codes.rs
@@ -1,9 +1,20 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Module containing error and warning codes used by the TAP aggregator JSON-RPC API.
+//!
+//! The JSON-RPC spec allocates error codes in the range `[-32000, -32099]` for application errors. We chose to use that
+//! range for both errors and warnings. We also chose error and warning codes that do not overlap, to reduce confusion.
+//! As such, the ranges are:
+//! - Errors: `[-32000, -32049]`, where `-32000` is reserved for all errors without a specific code.
+//! - Warnings: `[-32050, -32099]`, where `-32050` is reserved for all warnings without a specific code.
+
 /// JSON-RPC error codes specific to the TAP aggregator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum JsonRpcErrorCode {
+    /// -32000 -- Generic error.
+    #[allow(dead_code)]
+    GenericError = -32000,
     /// -32001 -- Invalid API version.
     InvalidVersionError = -32001,
     /// -32002 -- Error during receipt aggregation.
@@ -14,7 +25,11 @@ pub enum JsonRpcErrorCode {
 /// These are not part of the JSON-RPC spec, but are used to provide additional information to the
 /// client.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(dead_code)]
 pub enum JsonRpcWarningCode {
-    /// -32101 -- Requested API version is deprecated.
-    DeprecatedVersionWarning = -32101,
+    /// -32050 -- Generic warning.
+    #[allow(dead_code)]
+    GenericWarning = -32050,
+    /// -32051 -- Requested API version is deprecated.
+    DeprecatedVersionWarning = -32051,
 }

--- a/tap_aggregator/src/error_codes.rs
+++ b/tap_aggregator/src/error_codes.rs
@@ -14,11 +14,11 @@
 pub enum JsonRpcErrorCode {
     /// -32000 -- Generic error.
     #[allow(dead_code)]
-    GenericError = -32000,
+    Generic = -32000,
     /// -32001 -- Invalid API version.
-    InvalidVersionError = -32001,
+    InvalidVersion = -32001,
     /// -32002 -- Error during receipt aggregation.
-    AggregationError = -32002,
+    Aggregation = -32002,
 }
 
 /// JSON-RPC warning codes
@@ -29,7 +29,7 @@ pub enum JsonRpcErrorCode {
 pub enum JsonRpcWarningCode {
     /// -32050 -- Generic warning.
     #[allow(dead_code)]
-    GenericWarning = -32050,
+    Generic = -32050,
     /// -32051 -- Requested API version is deprecated.
-    DeprecatedVersionWarning = -32051,
+    DeprecatedVersion = -32051,
 }

--- a/tap_aggregator/src/server.rs
+++ b/tap_aggregator/src/server.rs
@@ -55,7 +55,7 @@ struct RpcImpl {
 fn parse_api_version(api_version: &str) -> Result<TapRpcApiVersion, JsonRpcError> {
     TapRpcApiVersion::from_str(api_version).map_err(|_| {
         jsonrpsee::types::ErrorObject::owned(
-            JsonRpcErrorCode::InvalidVersionError as i32,
+            JsonRpcErrorCode::InvalidVersion as i32,
             format!("Unsupported API version: \"{}\".", api_version),
             Some(tap_rpc_api_versions_info()),
         )
@@ -67,7 +67,7 @@ fn parse_api_version(api_version: &str) -> Result<TapRpcApiVersion, JsonRpcError
 fn check_api_version_deprecation(api_version: &TapRpcApiVersion) -> Option<JsonRpcWarning> {
     if TAP_RPC_API_VERSIONS_DEPRECATED.contains(api_version) {
         Some(JsonRpcWarning::new(
-            JsonRpcWarningCode::DeprecatedVersionWarning as i32,
+            JsonRpcWarningCode::DeprecatedVersion as i32,
             format!(
                 "The API version {} will be deprecated. \
                 Please check https://github.com/semiotic-ai/timeline_aggregation_protocol for more information.",
@@ -111,7 +111,7 @@ impl RpcServer for RpcImpl {
         match res {
             Ok(res) => Ok(JsonRpcResponse::warn(res, warnings)),
             Err(e) => Err(jsonrpsee::types::ErrorObject::owned(
-                JsonRpcErrorCode::AggregationError as i32,
+                JsonRpcErrorCode::Aggregation as i32,
                 e.to_string(),
                 None::<()>,
             )),


### PR DESCRIPTION
- Set errors values as [-32000,-32049]
- Set warning values as [-32050, -32099]
- Removing repeating "Error" and "Warning" postfixes.

fixes #102