### PR TITLE
fix: verification benchmarks

### DIFF
--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -17,11 +17,13 @@ ethers = "2.0.0"
 ethers-core = "2.0.0"
 ethers-contract = "2.0.0"
 ethers-contract-derive = "2.0.0"
-criterion = "0.4.0"
+
 strum = "0.24.1"
 strum_macros = "0.24.3"
 futures = "0.3.17"
 
+[dev-dependencies]
+criterion = { version = "0.5", features = ["async_std"] }
 
 [[bench]]
 name = 'timeline_aggretion_protocol_benchmark'

--- a/tap_core/benches/timeline_aggretion_protocol_benchmark.rs
+++ b/tap_core/benches/timeline_aggretion_protocol_benchmark.rs
@@ -10,67 +10,84 @@
 
 use std::str::FromStr;
 
+use async_std::task::block_on;
+use criterion::async_executor::AsyncStdExecutor;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ethereum_types::Address;
-use k256::ecdsa::{SigningKey, VerifyingKey};
+use ethers::signers::{LocalWallet, Signer, Wallet};
+use ethers_core::k256::ecdsa::SigningKey;
 use rand_core::OsRng;
 use tap_core::{
     eip_712_signed_message::EIP712SignedMessage,
     receipt_aggregate_voucher::ReceiptAggregateVoucher, tap_receipt::Receipt,
 };
 
-pub fn create_and_sign_receipt(
+pub async fn create_and_sign_receipt(
     allocation_id: Address,
     value: u128,
-    signing_key: &SigningKey,
+    wallet: &Wallet<SigningKey>,
 ) -> EIP712SignedMessage<Receipt> {
-    EIP712SignedMessage::new(Receipt::new(allocation_id, value).unwrap(), signing_key).unwrap()
+    EIP712SignedMessage::new(Receipt::new(allocation_id, value).unwrap(), wallet)
+        .await
+        .unwrap()
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let signing_key = SigningKey::random(&mut OsRng);
-    let verifying_key = VerifyingKey::from(&signing_key);
+    let wallet = LocalWallet::new(&mut OsRng);
 
     // Arbitrary values wrapped in black box to avoid compiler optimizing them out
-    let allocation_id =
-        black_box(Address::from_str("0xabababababababababababababababababababab").unwrap());
-    let value = black_box(12345u128);
+    let allocation_id = Address::from_str("0xabababababababababababababababababababab").unwrap();
+    let value = 12345u128;
 
     c.bench_function("Create Receipt", |b| {
-        b.iter(|| create_and_sign_receipt(allocation_id, value, &signing_key))
+        b.to_async(AsyncStdExecutor).iter(|| {
+            create_and_sign_receipt(
+                black_box(allocation_id),
+                black_box(value),
+                black_box(&wallet),
+            )
+        })
     });
 
-    let receipt = black_box(create_and_sign_receipt(allocation_id, value, &signing_key));
+    let receipt = block_on(create_and_sign_receipt(allocation_id, value, &wallet));
 
     c.bench_function("Validate Receipt", |b| {
-        b.iter(|| receipt.check_signature(verifying_key))
+        b.iter(|| {
+            black_box(&receipt)
+                .verify(black_box(wallet.address()))
+                .unwrap()
+        })
     });
 
     let mut rav_group = c.benchmark_group("Create RAV with varying input sizes");
 
     for log_number_of_receipts in 10..30 {
-        let receipts = black_box(
-            (0..2 ^ log_number_of_receipts)
-                .map(|_| create_and_sign_receipt(allocation_id, value, &signing_key))
-                .collect::<Vec<_>>(),
-        );
+        let receipts = (0..2 ^ log_number_of_receipts)
+            .map(|_| block_on(create_and_sign_receipt(allocation_id, value, &wallet)))
+            .collect::<Vec<_>>();
 
         rav_group.bench_function(
             &format!("Create RAV w/ 2^{} receipt's", log_number_of_receipts),
             |b| {
                 b.iter(|| {
-                    ReceiptAggregateVoucher::aggregate_receipts(allocation_id, &receipts, None)
+                    ReceiptAggregateVoucher::aggregate_receipts(
+                        black_box(allocation_id),
+                        black_box(&receipts),
+                        black_box(None),
+                    )
                 })
             },
         );
-        let signed_rav = black_box(EIP712SignedMessage::new(
+
+        let signed_rav = block_on(EIP712SignedMessage::new(
             ReceiptAggregateVoucher::aggregate_receipts(allocation_id, &receipts, None).unwrap(),
-            &signing_key,
+            &wallet,
         ))
         .unwrap();
+
         rav_group.bench_function(
             &format!("Validate RAV w/ 2^{} receipt's", log_number_of_receipts),
-            |b| b.iter(|| signed_rav.check_signature(verifying_key)),
+            |b| b.iter(|| black_box(&signed_rav).verify(black_box(wallet.address()))),
         );
     }
 }


### PR DESCRIPTION
Updated benchmarks so they compile and run.

closes https://github.com/semiotic-ai/timeline-aggregation-protocol/issues/70