### PR TITLE
Cargo publish

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -13,6 +13,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 #v1.8.0
+        with:
+          app_id: ${{ secrets.PR_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.PR_AUTOMATION_APP_PEM }}
+      - uses: google-github-actions/release-please-action@8016a6649226f2ec88ed05441c11bb5410a22d29 #v3.7.10
         with:
           command: manifest
+          token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -12,6 +12,8 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release-please.outputs.releases_created }}
     steps:
       - name: Generate token
         id: generate_token
@@ -19,7 +21,23 @@ jobs:
         with:
           app_id: ${{ secrets.PR_AUTOMATION_APP_ID }}
           private_key: ${{ secrets.PR_AUTOMATION_APP_PEM }}
-      - uses: google-github-actions/release-please-action@8016a6649226f2ec88ed05441c11bb5410a22d29 #v3.7.10
+      - name: Release please
+        id: release-please
+        uses: google-github-actions/release-please-action@8016a6649226f2ec88ed05441c11bb5410a22d29 #v3.7.10
         with:
           command: manifest
           token: ${{ steps.generate_token.outputs.token }}
+
+  publish-crates:
+    runs-on: ubuntu-latest
+    # run only if release-please had released a new version
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cargo-workspaces
+        run: cargo install cargo-workspaces
+      - name: Publish workspace crates
+        run: cargo workspaces publish --from-git -y
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"
+description = "A JSON-RPC service for the Timeline Aggregation Protocol that lets clients request an aggregate receipt from a list of individual receipts."
 
 [[bin]]
 name = "tap_aggregator"

--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -3,6 +3,7 @@ name="tap_core"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
+description = "Core Timeline Aggregation Protocol library: a fast, efficient and trustless unidirectional micro-payments system."
 
 [dependencies]
 primitive-types={version="0.12.1", features=["serde"]}

--- a/tap_integration_tests/Cargo.toml
+++ b/tap_integration_tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 autotests = false
-description = "Integration tests for the Time Aggregation Protocol."
+description = "Integration tests for the Timeline Aggregation Protocol."
 publish = false
 
 [dependencies]

--- a/tap_integration_tests/Cargo.toml
+++ b/tap_integration_tests/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 autotests = false
+description = "Integration tests for the Time Aggregation Protocol."
 
 [dependencies]
 tap_aggregator = { path = "../tap_aggregator" }

--- a/tap_integration_tests/Cargo.toml
+++ b/tap_integration_tests/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 autotests = false
 description = "Integration tests for the Time Aggregation Protocol."
+publish = false
 
 [dependencies]
 tap_aggregator = { path = "../tap_aggregator" }


### PR DESCRIPTION
- A few fixes / adjustments to `cargo.toml`s make publishing possible.
- Using a Github App token for `release-please`, so that its PRs can run CI. [More info here](https://github.com/peter-evans/create-pull-request/blob/5f8399b325911a0981ba132a51cceecce543d255/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens)
- Adding a `cargo workspaces publish` step after `release-please`. Runs only if a new release is created.