### PR TITLE
build: fix local deps versions.

### DIFF
--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.70"
 tokio = { version = "1.27.0", features = ["macros", "signal"] }
-tap_core = { path = "../tap_core" }
+tap_core = { version = "0.1.0", path = "../tap_core" }
 jsonrpsee = { version = "0.18.0", features = ["server", "macros"] }
 ethers-signers = "2.0.3"
 clap = { version = "4.2.4", features = ["derive", "env"] }

--- a/tap_integration_tests/Cargo.toml
+++ b/tap_integration_tests/Cargo.toml
@@ -8,8 +8,8 @@ description = "Integration tests for the Timeline Aggregation Protocol."
 publish = false
 
 [dependencies]
-tap_aggregator = { path = "../tap_aggregator" }
-tap_core = { path = "../tap_core" }
+tap_aggregator = { version = "0.1.0", path = "../tap_aggregator" }
+tap_core = { version = "0.1.0", path = "../tap_core" }
 jsonrpsee = { version = "0.18.0", features = ["http-client", "server"] }
 ethers = "2.0.0"
 clap = { version = "4.2.4", features = ["derive", "env"] }


### PR DESCRIPTION
The lack of a version upsets `cargo publish`.
`release-please` will update the version of local `path` dependencies automatically.