### PR TITLE
refactor(rav_storage_adapter)!: simplify trait

### DIFF
--- a/tap_core/src/adapters/rav_storage_adapter.rs
+++ b/tap_core/src/adapters/rav_storage_adapter.rs
@@ -1,21 +1,12 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    eip_712_signed_message::EIP712SignedMessage, receipt_aggregate_voucher::ReceiptAggregateVoucher,
-};
+use crate::tap_manager::SignedRAV;
 
 pub trait RAVStorageAdapter {
     /// User defined error type;
     type AdapterError: std::error::Error + std::fmt::Debug;
 
-    fn store_rav(
-        &mut self,
-        rav: EIP712SignedMessage<ReceiptAggregateVoucher>,
-    ) -> Result<u64, Self::AdapterError>;
-    fn retrieve_rav_by_id(
-        &self,
-        rav_id: u64,
-    ) -> Result<EIP712SignedMessage<ReceiptAggregateVoucher>, Self::AdapterError>;
-    fn remove_rav_by_id(&mut self, rav_id: u64) -> Result<(), Self::AdapterError>;
+    fn update_last_rav(&mut self, rav: SignedRAV) -> Result<(), Self::AdapterError>;
+    fn last_rav(&self) -> Result<Option<SignedRAV>, Self::AdapterError>;
 }

--- a/tap_core/src/adapters/test/rav_storage_adapter_mock.rs
+++ b/tap_core/src/adapters/test/rav_storage_adapter_mock.rs
@@ -1,32 +1,22 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::sync::{Arc, RwLock};
 
-use crate::adapters::rav_storage_adapter::RAVStorageAdapter;
-use crate::eip_712_signed_message::EIP712SignedMessage;
-use crate::receipt_aggregate_voucher::ReceiptAggregateVoucher;
+use thiserror::Error;
+
+use crate::{adapters::rav_storage_adapter::RAVStorageAdapter, tap_manager::SignedRAV};
 
 pub struct RAVStorageAdapterMock {
-    rav_storage: Arc<RwLock<HashMap<u64, EIP712SignedMessage<ReceiptAggregateVoucher>>>>,
-    unique_id: u64,
+    rav_storage: Arc<RwLock<Option<SignedRAV>>>,
 }
 
 impl RAVStorageAdapterMock {
-    pub fn new(
-        rav_storage: Arc<RwLock<HashMap<u64, EIP712SignedMessage<ReceiptAggregateVoucher>>>>,
-    ) -> Self {
-        RAVStorageAdapterMock {
-            rav_storage,
-            unique_id: 0u64,
-        }
+    pub fn new(rav_storage: Arc<RwLock<Option<SignedRAV>>>) -> Self {
+        RAVStorageAdapterMock { rav_storage }
     }
 }
 
-use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum AdpaterErrorMock {
     #[error("something went wrong: {error}")]
@@ -36,36 +26,12 @@ pub enum AdpaterErrorMock {
 impl RAVStorageAdapter for RAVStorageAdapterMock {
     type AdapterError = AdpaterErrorMock;
 
-    fn store_rav(
-        &mut self,
-        rav: EIP712SignedMessage<ReceiptAggregateVoucher>,
-    ) -> Result<u64, Self::AdapterError> {
-        let id = self.unique_id;
+    fn update_last_rav(&mut self, rav: SignedRAV) -> Result<(), Self::AdapterError> {
         let mut rav_storage = self.rav_storage.write().unwrap();
-        rav_storage.insert(id, rav);
-        self.unique_id += 1;
-        Ok(id)
+        *rav_storage = Some(rav);
+        Ok(())
     }
-    fn retrieve_rav_by_id(
-        &self,
-        rav_id: u64,
-    ) -> Result<EIP712SignedMessage<ReceiptAggregateVoucher>, Self::AdapterError> {
-        let rav_storage = self.rav_storage.read().unwrap();
-        rav_storage
-            .get(&rav_id)
-            .cloned()
-            .ok_or(AdpaterErrorMock::AdapterError {
-                error: "No RAV found with ID".to_owned(),
-            })
-    }
-    fn remove_rav_by_id(&mut self, rav_id: u64) -> Result<(), Self::AdapterError> {
-        let mut rav_storage = self.rav_storage.write().unwrap();
-
-        rav_storage
-            .remove(&rav_id)
-            .map(|_| ())
-            .ok_or(AdpaterErrorMock::AdapterError {
-                error: "No RAV found with ID".to_owned(),
-            })
+    fn last_rav(&self) -> Result<Option<SignedRAV>, Self::AdapterError> {
+        Ok(self.rav_storage.read().unwrap().clone())
     }
 }

--- a/tap_core/src/eip_712_signed_message.rs
+++ b/tap_core/src/eip_712_signed_message.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Error, Result};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct EIP712SignedMessage<M: eip712::Eip712 + Send + Sync> {
     /// Message to be signed
     pub message: M,

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -58,7 +58,7 @@ mod manager_unit_test {
 
     #[fixture]
     fn rav_storage_adapter() -> RAVStorageAdapterMock {
-        let rav_storage = Arc::new(RwLock::new(HashMap::new()));
+        let rav_storage = Arc::new(RwLock::new(None));
 
         RAVStorageAdapterMock::new(rav_storage)
     }

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -178,7 +178,7 @@ fn receipt_checks_adapter(
 // A structure for storing received RAVs.
 #[fixture]
 fn rav_storage_adapter() -> RAVStorageAdapterMock {
-    RAVStorageAdapterMock::new(Arc::new(RwLock::new(HashMap::new())))
+    RAVStorageAdapterMock::new(Arc::new(RwLock::new(None)))
 }
 
 // These are the checks that the Indexer will perform when requesting a RAV.


### PR DESCRIPTION
Simplifying the trait to the minimum that is needed for the TAP manager to function: only needs to store and retrieve the last RAV for each allocation. The user is free to add more functionality if needed.

BREAKING CHANGE: the RavStorageAdapter public trait has changed