### PR TITLE
Fix: Receipts w/ consecutive timestamps failed

### DIFF
--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -158,7 +158,7 @@ impl<
         let expected_rav = Self::generate_expected_rav(&valid_receipts, previous_rav.clone())?;
 
         self.receipt_auditor
-            .update_min_timestamp_ns(expected_rav.timestamp_ns + 1);
+            .update_min_timestamp_ns(expected_rav.timestamp_ns);
 
         Ok(RAVRequest {
             valid_receipts,

--- a/tap_core/src/tap_receipt/receipt_auditor.rs
+++ b/tap_core/src/tap_receipt/receipt_auditor.rs
@@ -30,6 +30,7 @@ impl<CA: CollateralAdapter, RCA: ReceiptChecksAdapter> ReceiptAuditor<CA, RCA> {
         }
     }
 
+    /// Updates the minimum timestamp that will be accepted for a receipt (exclusive).
     pub fn update_min_timestamp_ns(&mut self, min_timestamp_ns: u64) {
         self.min_timestamp_ns = min_timestamp_ns;
     }


### PR DESCRIPTION
Added a test (that initially failed):
- Create 20 receipts with consecutive timestamps (eg. 1, 2, 3...)
- Receive the first 10
- Create RAV
- Receive remaining 10
- Create RAV (w/ previous RAV)
- Check failed receipts and total expected amount

The fix is self-explanatory.