### PR TITLE
feat(receipt_storage_adapter): Use RangeBounds

### DIFF
--- a/tap_core/src/adapters/receipt_storage_adapter.rs
+++ b/tap_core/src/adapters/receipt_storage_adapter.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Range;
+use std::ops::RangeBounds;
 
 use crate::tap_receipt::ReceivedReceipt;
 
@@ -22,9 +22,9 @@ pub trait ReceiptStorageAdapter {
         &self,
         timestamp_ns: u64,
     ) -> Result<Vec<(u64, ReceivedReceipt)>, Self::AdapterError>;
-    fn retrieve_receipts_in_timestamp_range(
+    fn retrieve_receipts_in_timestamp_range<R: RangeBounds<u64>>(
         &self,
-        timestamp_range_ns: Range<u64>,
+        timestamp_range_ns: R,
     ) -> Result<Vec<(u64, ReceivedReceipt)>, Self::AdapterError>;
     fn update_receipt_by_id(
         &mut self,
@@ -33,8 +33,8 @@ pub trait ReceiptStorageAdapter {
     ) -> Result<(), Self::AdapterError>;
     fn remove_receipt_by_id(&mut self, receipt_id: u64) -> Result<(), Self::AdapterError>;
     fn remove_receipts_by_ids(&mut self, receipt_ids: &[u64]) -> Result<(), Self::AdapterError>;
-    fn remove_receipts_in_timestamp_range(
+    fn remove_receipts_in_timestamp_range<R: RangeBounds<u64>>(
         &mut self,
-        timestamp_ns: Range<u64>,
+        timestamp_ns: R,
     ) -> Result<(), Self::AdapterError>;
 }

--- a/tap_core/src/adapters/test/receipt_storage_adapter_mock.rs
+++ b/tap_core/src/adapters/test/receipt_storage_adapter_mock.rs
@@ -86,19 +86,7 @@ impl ReceiptStorageAdapter for ReceiptStorageAdapterMock {
         &self,
         timestamp_ns: u64,
     ) -> Result<Vec<(u64, ReceivedReceipt)>, Self::AdapterError> {
-        let receipt_storage =
-            self.receipt_storage
-                .read()
-                .map_err(|e| Self::AdapterError::AdapterError {
-                    error: e.to_string(),
-                })?;
-        Ok(receipt_storage
-            .iter()
-            .filter(|(_, rx_receipt)| {
-                rx_receipt.signed_receipt.message.timestamp_ns <= timestamp_ns
-            })
-            .map(|(&id, rx_receipt)| (id, rx_receipt.clone()))
-            .collect())
+        self.retrieve_receipts_in_timestamp_range(..=timestamp_ns)
     }
     fn retrieve_receipts_in_timestamp_range<R: RangeBounds<u64>>(
         &self,

--- a/tap_core/src/adapters/test/receipt_storage_adapter_mock.rs
+++ b/tap_core/src/adapters/test/receipt_storage_adapter_mock.rs
@@ -3,7 +3,7 @@
 
 use std::{
     collections::HashMap,
-    ops::Range,
+    ops::RangeBounds,
     sync::{Arc, RwLock},
 };
 
@@ -100,9 +100,9 @@ impl ReceiptStorageAdapter for ReceiptStorageAdapterMock {
             .map(|(&id, rx_receipt)| (id, rx_receipt.clone()))
             .collect())
     }
-    fn retrieve_receipts_in_timestamp_range(
+    fn retrieve_receipts_in_timestamp_range<R: RangeBounds<u64>>(
         &self,
-        timestamp_range_ns: Range<u64>,
+        timestamp_range_ns: R,
     ) -> Result<Vec<(u64, ReceivedReceipt)>, Self::AdapterError> {
         let receipt_storage =
             self.receipt_storage
@@ -160,9 +160,9 @@ impl ReceiptStorageAdapter for ReceiptStorageAdapterMock {
         }
         Ok(())
     }
-    fn remove_receipts_in_timestamp_range(
+    fn remove_receipts_in_timestamp_range<R: RangeBounds<u64>>(
         &mut self,
-        timestamp_ns: Range<u64>,
+        timestamp_ns: R,
     ) -> Result<(), Self::AdapterError> {
         let mut receipt_storage =
             self.receipt_storage


### PR DESCRIPTION
Makes functions that take ranges generic over the type of range (inclusive, exclusive, UpTo, etc).

I need this to concisely implement a solution for #108 , and perhaps later also prune the trait further.