### PR TITLE
feat(manager): add receipts_auto_delete

### DIFF
--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -135,7 +135,9 @@ impl<
         Ok(())
     }
 
-    /// Removes all receipts that have a timestamp less or equal than the last RAV timestamp_max.
+    /// Removes obsolete receipts from storage. Obsolete receipts are receipts that are older than the last RAV, and 
+    /// therefore already aggregated into the RAV.
+    /// This function should be called after a new RAV is received to limit the number of receipts stored.
     /// No-op if there is no last RAV.
     ///
     /// # Errors

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -144,7 +144,7 @@ impl<
     ///
     /// Returns [`Error::AdapterError`] if there are any errors while retrieving last RAV or removing receipts
     ///
-    pub fn remove_receipts_older_than_last_rav(&mut self) -> Result<(), Error> {
+    pub fn remove_obsolete_receipts(&mut self) -> Result<(), Error> {
         match self.get_previous_rav()? {
             Some(last_rav) => {
                 self.receipt_storage_adapter

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -135,7 +135,7 @@ impl<
         Ok(())
     }
 
-    /// Removes obsolete receipts from storage. Obsolete receipts are receipts that are older than the last RAV, and 
+    /// Removes obsolete receipts from storage. Obsolete receipts are receipts that are older than the last RAV, and
     /// therefore already aggregated into the RAV.
     /// This function should be called after a new RAV is received to limit the number of receipts stored.
     /// No-op if there is no last RAV.

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -389,7 +389,7 @@ mod manager_test {
         // Remove old receipts if requested
         // This shouldn't do anything since there has been no rav created yet
         if remove_old_receipts {
-            manager.remove_receipts_older_than_last_rav().unwrap();
+            manager.remove_obsolete_receipts().unwrap();
         }
 
         let rav_request_1_result = manager.create_rav_request(0);
@@ -437,7 +437,7 @@ mod manager_test {
 
         // Remove old receipts if requested
         if remove_old_receipts {
-            manager.remove_receipts_older_than_last_rav().unwrap();
+            manager.remove_obsolete_receipts().unwrap();
             // We expect to have 10 receipts left in receipt storage
             assert_eq!(
                 manager

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -440,7 +440,8 @@ mod manager_test {
             manager.remove_receipts_older_than_last_rav().unwrap();
             // We expect to have 10 receipts left in receipt storage
             assert_eq!(
-                manager.receipt_storage_adapter
+                manager
+                    .receipt_storage_adapter
                     .retrieve_receipts_in_timestamp_range(..)
                     .unwrap()
                     .len(),


### PR DESCRIPTION
`receipts_auto_delete` is a function that deletes receipts that are older than the last RAV.

Had to hack a bit with the tests to reduce code duplication:
- Using a test matrix instead of cases in `manager_create_multiple_rav_requests_all_valid_receipts_consecutive_timestamps`. The tests will run with and without the "receipts auto delete" right before the 1st and 2nd RAV.
- To make sure that the right number of receipts gets deleted, I needed to access the private `receipt_storage_adapter` attribute of `Manager`. Since the tests were originally outside the `Manager` source file (integration tests), I created a test helper function in the `Manager` source file that exposes the private `receipt_storage_adapter` attribute.

Fixes #108 