### PR TITLE
refactor(receipt_storage_adapter)!: prune trait

### DIFF
--- a/tap_core/src/adapters/receipt_storage_adapter.rs
+++ b/tap_core/src/adapters/receipt_storage_adapter.rs
@@ -10,18 +10,6 @@ pub trait ReceiptStorageAdapter {
     type AdapterError: std::error::Error + std::fmt::Debug;
 
     fn store_receipt(&mut self, receipt: ReceivedReceipt) -> Result<u64, Self::AdapterError>;
-    fn retrieve_receipt_by_id(
-        &self,
-        receipt_id: u64,
-    ) -> Result<ReceivedReceipt, Self::AdapterError>;
-    fn retrieve_receipts_by_timestamp(
-        &self,
-        timestamp_ns: u64,
-    ) -> Result<Vec<(u64, ReceivedReceipt)>, Self::AdapterError>;
-    fn retrieve_receipts_upto_timestamp(
-        &self,
-        timestamp_ns: u64,
-    ) -> Result<Vec<(u64, ReceivedReceipt)>, Self::AdapterError>;
     fn retrieve_receipts_in_timestamp_range<R: RangeBounds<u64>>(
         &self,
         timestamp_range_ns: R,
@@ -31,8 +19,6 @@ pub trait ReceiptStorageAdapter {
         receipt_id: u64,
         receipt: ReceivedReceipt,
     ) -> Result<(), Self::AdapterError>;
-    fn remove_receipt_by_id(&mut self, receipt_id: u64) -> Result<(), Self::AdapterError>;
-    fn remove_receipts_by_ids(&mut self, receipt_ids: &[u64]) -> Result<(), Self::AdapterError>;
     fn remove_receipts_in_timestamp_range<R: RangeBounds<u64>>(
         &mut self,
         timestamp_ns: R,

--- a/tap_core/src/adapters/test/receipt_storage_adapter_mock.rs
+++ b/tap_core/src/adapters/test/receipt_storage_adapter_mock.rs
@@ -23,6 +23,68 @@ impl ReceiptStorageAdapterMock {
             unique_id: 0u64,
         }
     }
+    pub fn retrieve_receipt_by_id(
+        &self,
+        receipt_id: u64,
+    ) -> Result<ReceivedReceipt, AdpaterErrorMock> {
+        let receipt_storage =
+            self.receipt_storage
+                .read()
+                .map_err(|e| AdpaterErrorMock::AdapterError {
+                    error: e.to_string(),
+                })?;
+
+        receipt_storage
+            .get(&receipt_id)
+            .cloned()
+            .ok_or(AdpaterErrorMock::AdapterError {
+                error: "No receipt found with ID".to_owned(),
+            })
+    }
+    pub fn retrieve_receipts_by_timestamp(
+        &self,
+        timestamp_ns: u64,
+    ) -> Result<Vec<(u64, ReceivedReceipt)>, AdpaterErrorMock> {
+        let receipt_storage =
+            self.receipt_storage
+                .read()
+                .map_err(|e| AdpaterErrorMock::AdapterError {
+                    error: e.to_string(),
+                })?;
+        Ok(receipt_storage
+            .iter()
+            .filter(|(_, rx_receipt)| {
+                rx_receipt.signed_receipt.message.timestamp_ns == timestamp_ns
+            })
+            .map(|(&id, rx_receipt)| (id, rx_receipt.clone()))
+            .collect())
+    }
+    pub fn retrieve_receipts_upto_timestamp(
+        &self,
+        timestamp_ns: u64,
+    ) -> Result<Vec<(u64, ReceivedReceipt)>, AdpaterErrorMock> {
+        self.retrieve_receipts_in_timestamp_range(..=timestamp_ns)
+    }
+    pub fn remove_receipt_by_id(&mut self, receipt_id: u64) -> Result<(), AdpaterErrorMock> {
+        let mut receipt_storage =
+            self.receipt_storage
+                .write()
+                .map_err(|e| AdpaterErrorMock::AdapterError {
+                    error: e.to_string(),
+                })?;
+        receipt_storage
+            .remove(&receipt_id)
+            .map(|_| ())
+            .ok_or(AdpaterErrorMock::AdapterError {
+                error: "No receipt found with ID".to_owned(),
+            })
+    }
+    pub fn remove_receipts_by_ids(&mut self, receipt_ids: &[u64]) -> Result<(), AdpaterErrorMock> {
+        for receipt_id in receipt_ids {
+            self.remove_receipt_by_id(*receipt_id)?;
+        }
+        Ok(())
+    }
 }
 
 use thiserror::Error;
@@ -45,48 +107,6 @@ impl ReceiptStorageAdapter for ReceiptStorageAdapterMock {
         receipt_storage.insert(id, receipt);
         self.unique_id += 1;
         Ok(id)
-    }
-    fn retrieve_receipt_by_id(
-        &self,
-        receipt_id: u64,
-    ) -> Result<ReceivedReceipt, Self::AdapterError> {
-        let receipt_storage =
-            self.receipt_storage
-                .read()
-                .map_err(|e| Self::AdapterError::AdapterError {
-                    error: e.to_string(),
-                })?;
-
-        receipt_storage
-            .get(&receipt_id)
-            .cloned()
-            .ok_or(AdpaterErrorMock::AdapterError {
-                error: "No receipt found with ID".to_owned(),
-            })
-    }
-    fn retrieve_receipts_by_timestamp(
-        &self,
-        timestamp_ns: u64,
-    ) -> Result<Vec<(u64, ReceivedReceipt)>, Self::AdapterError> {
-        let receipt_storage =
-            self.receipt_storage
-                .read()
-                .map_err(|e| Self::AdapterError::AdapterError {
-                    error: e.to_string(),
-                })?;
-        Ok(receipt_storage
-            .iter()
-            .filter(|(_, rx_receipt)| {
-                rx_receipt.signed_receipt.message.timestamp_ns == timestamp_ns
-            })
-            .map(|(&id, rx_receipt)| (id, rx_receipt.clone()))
-            .collect())
-    }
-    fn retrieve_receipts_upto_timestamp(
-        &self,
-        timestamp_ns: u64,
-    ) -> Result<Vec<(u64, ReceivedReceipt)>, Self::AdapterError> {
-        self.retrieve_receipts_in_timestamp_range(..=timestamp_ns)
     }
     fn retrieve_receipts_in_timestamp_range<R: RangeBounds<u64>>(
         &self,
@@ -126,26 +146,6 @@ impl ReceiptStorageAdapter for ReceiptStorageAdapterMock {
 
         receipt_storage.insert(receipt_id, receipt);
         self.unique_id += 1;
-        Ok(())
-    }
-    fn remove_receipt_by_id(&mut self, receipt_id: u64) -> Result<(), Self::AdapterError> {
-        let mut receipt_storage =
-            self.receipt_storage
-                .write()
-                .map_err(|e| Self::AdapterError::AdapterError {
-                    error: e.to_string(),
-                })?;
-        receipt_storage
-            .remove(&receipt_id)
-            .map(|_| ())
-            .ok_or(AdpaterErrorMock::AdapterError {
-                error: "No receipt found with ID".to_owned(),
-            })
-    }
-    fn remove_receipts_by_ids(&mut self, receipt_ids: &[u64]) -> Result<(), Self::AdapterError> {
-        for receipt_id in receipt_ids {
-            self.remove_receipt_by_id(*receipt_id)?;
-        }
         Ok(())
     }
     fn remove_receipts_in_timestamp_range<R: RangeBounds<u64>>(

--- a/tap_core/src/adapters/test/receipt_storage_adapter_mock.rs
+++ b/tap_core/src/adapters/test/receipt_storage_adapter_mock.rs
@@ -26,29 +26,29 @@ impl ReceiptStorageAdapterMock {
     pub fn retrieve_receipt_by_id(
         &self,
         receipt_id: u64,
-    ) -> Result<ReceivedReceipt, AdpaterErrorMock> {
+    ) -> Result<ReceivedReceipt, AdapterErrorMock> {
         let receipt_storage =
             self.receipt_storage
                 .read()
-                .map_err(|e| AdpaterErrorMock::AdapterError {
+                .map_err(|e| AdapterErrorMock::AdapterError {
                     error: e.to_string(),
                 })?;
 
         receipt_storage
             .get(&receipt_id)
             .cloned()
-            .ok_or(AdpaterErrorMock::AdapterError {
+            .ok_or(AdapterErrorMock::AdapterError {
                 error: "No receipt found with ID".to_owned(),
             })
     }
     pub fn retrieve_receipts_by_timestamp(
         &self,
         timestamp_ns: u64,
-    ) -> Result<Vec<(u64, ReceivedReceipt)>, AdpaterErrorMock> {
+    ) -> Result<Vec<(u64, ReceivedReceipt)>, AdapterErrorMock> {
         let receipt_storage =
             self.receipt_storage
                 .read()
-                .map_err(|e| AdpaterErrorMock::AdapterError {
+                .map_err(|e| AdapterErrorMock::AdapterError {
                     error: e.to_string(),
                 })?;
         Ok(receipt_storage
@@ -62,24 +62,24 @@ impl ReceiptStorageAdapterMock {
     pub fn retrieve_receipts_upto_timestamp(
         &self,
         timestamp_ns: u64,
-    ) -> Result<Vec<(u64, ReceivedReceipt)>, AdpaterErrorMock> {
+    ) -> Result<Vec<(u64, ReceivedReceipt)>, AdapterErrorMock> {
         self.retrieve_receipts_in_timestamp_range(..=timestamp_ns)
     }
-    pub fn remove_receipt_by_id(&mut self, receipt_id: u64) -> Result<(), AdpaterErrorMock> {
+    pub fn remove_receipt_by_id(&mut self, receipt_id: u64) -> Result<(), AdapterErrorMock> {
         let mut receipt_storage =
             self.receipt_storage
                 .write()
-                .map_err(|e| AdpaterErrorMock::AdapterError {
+                .map_err(|e| AdapterErrorMock::AdapterError {
                     error: e.to_string(),
                 })?;
         receipt_storage
             .remove(&receipt_id)
             .map(|_| ())
-            .ok_or(AdpaterErrorMock::AdapterError {
+            .ok_or(AdapterErrorMock::AdapterError {
                 error: "No receipt found with ID".to_owned(),
             })
     }
-    pub fn remove_receipts_by_ids(&mut self, receipt_ids: &[u64]) -> Result<(), AdpaterErrorMock> {
+    pub fn remove_receipts_by_ids(&mut self, receipt_ids: &[u64]) -> Result<(), AdapterErrorMock> {
         for receipt_id in receipt_ids {
             self.remove_receipt_by_id(*receipt_id)?;
         }
@@ -89,13 +89,13 @@ impl ReceiptStorageAdapterMock {
 
 use thiserror::Error;
 #[derive(Debug, Error)]
-pub enum AdpaterErrorMock {
+pub enum AdapterErrorMock {
     #[error("something went wrong: {error}")]
     AdapterError { error: String },
 }
 
 impl ReceiptStorageAdapter for ReceiptStorageAdapterMock {
-    type AdapterError = AdpaterErrorMock;
+    type AdapterError = AdapterErrorMock;
     fn store_receipt(&mut self, receipt: ReceivedReceipt) -> Result<u64, Self::AdapterError> {
         let id = self.unique_id;
         let mut receipt_storage =
@@ -139,7 +139,7 @@ impl ReceiptStorageAdapter for ReceiptStorageAdapterMock {
                 })?;
 
         if !receipt_storage.contains_key(&receipt_id) {
-            return Err(AdpaterErrorMock::AdapterError {
+            return Err(AdapterErrorMock::AdapterError {
                 error: "Invalid receipt_id".to_owned(),
             });
         };


### PR DESCRIPTION
BREAKING CHANGE: all functions unnecessary to the TAP manager have been removed from the `ReceiptStorageAdapter` trait.

Note: `remove_receipts_in_timestamp_range` will be made necessary by #130 