### PR TITLE
ci: test doc's code snippets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,9 @@ jobs:
       - run: cargo install cargo-llvm-cov
       - name: Run tests and generate coverage report
         run: cargo llvm-cov test --all-features --workspace --lcov --output-path lcov.info 
-      - name: Coveralls
+      - name: Test documentation code snippets
+        run: cargo test --doc --all-features --workspace
+      - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2.2.0
         with:
           file: ./lcov.info


### PR DESCRIPTION
We can't rely on `cargo llvm-cov test`, which doesn't by default because of https://github.com/taiki-e/cargo-llvm-cov/issues/2