### PR TITLE
chore: cleanup tap_core deps

### DIFF
--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 description = "Core Timeline Aggregation Protocol library: a fast, efficient and trustless unidirectional micro-payments system."
 
 [dependencies]
-primitive-types={version="0.12.1", features=["serde"]}
 rand_core="0.6.4"
 serde={ version="1.0", features=["derive"] }
 rand="0.8.5"
@@ -14,7 +13,7 @@ thiserror="1.0.38"
 ethereum-types={version="0.14.1"}
 rstest = "0.17.0"
 async-std = { version = "1.5", features = ["attributes"] }
-ethers = "2.0.0"
+ethers = { version = "2.0.0", default-features = false }
 ethers-core = "2.0.0"
 ethers-contract = "2.0.0"
 ethers-contract-derive = "2.0.0"
@@ -22,10 +21,10 @@ anyhow = "1"
 
 strum = "0.24.1"
 strum_macros = "0.24.3"
-futures = "0.3.17"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_std"] }
+futures = "0.3.17"
 
 [[bench]]
 name = 'timeline_aggretion_protocol_benchmark'


### PR DESCRIPTION
This removes some unused dependencies from tap_core.
```bash
$ (cd tap_core && cargo tree | wc -l) # before
842
$ (cd tap_core && cargo tree | wc -l) # after
783
```