### PR TITLE
ci: fix clippy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-cargo-clippy
       - run: |
            rustup component add clippy
-           cargo clippy --all-features -- -D clippy::all
+           cargo clippy --all-targets --all-features -- -D warnings
   
   test-and-coverage:
     name: cargo test and coverage

--- a/tap_aggregator/src/aggregator.rs
+++ b/tap_aggregator/src/aggregator.rs
@@ -149,7 +149,7 @@ mod tests {
                 .await
                 .unwrap();
         receipts.push(receipt.clone());
-        receipts.push(receipt.clone());
+        receipts.push(receipt);
 
         let res = aggregator::check_signatures_unique(&receipts);
         assert!(res.is_err());

--- a/tap_aggregator/src/main.rs
+++ b/tap_aggregator/src/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use ethers_signers::{coins_bip39::English, MnemonicBuilder};
 use tokio::signal::unix::{signal, SignalKind};
 
-use log::{debug, info, warn};
+use log::{debug, info};
 use tap_aggregator::metrics;
 use tap_aggregator::server;
 

--- a/tap_core/src/adapters/test/receipt_checks_adapter_test.rs
+++ b/tap_core/src/adapters/test/receipt_checks_adapter_test.rs
@@ -68,10 +68,7 @@ mod receipt_checks_adapter_unit_test {
             .await;
         let receipt_storage = Arc::new(RwLock::new(receipts));
 
-        let query_appraisals = (0..11)
-            .into_iter()
-            .map(|id| (id, 100u128))
-            .collect::<HashMap<_, _>>();
+        let query_appraisals = (0..11).map(|id| (id, 100u128)).collect::<HashMap<_, _>>();
 
         let query_appraisals_storage = Arc::new(RwLock::new(query_appraisals));
 

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -1,8 +1,8 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
-#[cfg(test)]
 
-mod manager_test {
+#[cfg(test)]
+mod manager_unit_test {
     use std::{
         collections::{HashMap, HashSet},
         str::FromStr,

--- a/tap_integration_tests/clippy.toml
+++ b/tap_integration_tests/clippy.toml
@@ -1,0 +1,2 @@
+# Since this whole crate is only for testing, we relax some of the clippy rules
+too-many-arguments-threshold = 15

--- a/tap_integration_tests/tests/indexer_mock/mod.rs
+++ b/tap_integration_tests/tests/indexer_mock/mod.rs
@@ -96,7 +96,7 @@ impl<
             receipt_count: Arc::new(AtomicU64::new(0)),
             threshold,
             aggregator_client: (
-                HttpClientBuilder::default().build(format!("{}", aggregate_server_address))?,
+                HttpClientBuilder::default().build(aggregate_server_address.to_string())?,
                 aggregate_server_api_version,
             ),
         })
@@ -234,8 +234,7 @@ async fn request_rav<
         .await?;
     {
         let mut manager_guard = manager.lock().await;
-        let _result =
-            manager_guard.verify_and_store_rav(rav_request.expected_rav, remote_rav_result.data)?;
+        manager_guard.verify_and_store_rav(rav_request.expected_rav, remote_rav_result.data)?;
     }
 
     // For these tests, we expect every receipt to be valid, i.e. there should be no invalid receipts, nor any missing receipts (less than the expected threshold).
@@ -259,5 +258,5 @@ fn get_current_timestamp_u64_ns() -> Result<u64> {
 }
 
 fn to_rpc_error(e: Box<dyn std::error::Error>, msg: &str) -> jsonrpsee::types::ErrorObjectOwned {
-    jsonrpsee::types::ErrorObject::owned(-32000, format!("{} - {}", e.to_string(), msg), None::<()>)
+    jsonrpsee::types::ErrorObject::owned(-32000, format!("{} - {}", e, msg), None::<()>)
 }

--- a/tap_integration_tests/tests/indexer_mock/mod.rs
+++ b/tap_integration_tests/tests/indexer_mock/mod.rs
@@ -96,7 +96,7 @@ impl<
             receipt_count: Arc::new(AtomicU64::new(0)),
             threshold,
             aggregator_client: (
-                HttpClientBuilder::default().build(aggregate_server_address.to_string())?,
+                HttpClientBuilder::default().build(aggregate_server_address)?,
                 aggregate_server_api_version,
             ),
         })

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -796,8 +796,7 @@ async fn test_tap_aggregator_rav_timestamp_cuttoff(
         http_max_concurrent_connections,
     )
     .await?;
-    let client =
-        HttpClientBuilder::default().build(format!("http://{}", gateway_addr.to_string()))?;
+    let client = HttpClientBuilder::default().build(format!("http://{}", gateway_addr))?;
 
     // This is the first part of the test, two batches of receipts are sent to the aggregator.
     // The second batch has one receipt with the same timestamp as the latest receipt in the first batch.


### PR DESCRIPTION
2 fixes for the clippy checks:
- Fail on warnings
- `--all-targets`, which somehow unearthed a lot of warnings

Then I fixed all the warnings in several passes.