### PR TITLE
docs(tap-core): update rav and receipt constructors to remove outdate…

### DIFF
--- a/tap_core/src/receipt_aggregate_voucher.rs
+++ b/tap_core/src/receipt_aggregate_voucher.rs
@@ -38,7 +38,7 @@ pub struct ReceiptAggregateVoucher {
 }
 
 impl ReceiptAggregateVoucher {
-    /// Aggregates a batch of validated receipts with optional validated previous RAV, returning a new signed RAV if all provided items are valid or an error if not.
+    /// Aggregates a batch of validated receipts with optional validated previous RAV, returning a new RAV if all provided items are valid or an error if not.
     ///
     /// # Errors
     ///

--- a/tap_core/src/tap_receipt/receipt.rs
+++ b/tap_core/src/tap_receipt/receipt.rs
@@ -35,7 +35,7 @@ pub struct Receipt {
 }
 
 impl Receipt {
-    /// Returns a receipt with provided values signed with `signing_key`
+    /// Returns a receipt with provided values
     pub fn new(allocation_id: Address, value: u128) -> crate::Result<Self> {
         let timestamp_ns = crate::get_current_timestamp_u64_ns()?;
         let nonce = thread_rng().gen::<u64>();


### PR DESCRIPTION
…d information

signing has been moved to be handled in eip_712_signed_message struct and no longer happens in the constructor of RAV and Receipt. The documentation was not updated when the change happened. This commit corrects that information.