### PR TITLE
feat: serde for ReceivedReceipt

### DIFF
--- a/tap_core/src/tap_receipt/mod.rs
+++ b/tap_core/src/tap_receipt/mod.rs
@@ -10,10 +10,11 @@ use ethereum_types::Address;
 pub use receipt::Receipt;
 pub use receipt_auditor::ReceiptAuditor;
 pub use received_receipt::{RAVStatus, ReceiptState, ReceivedReceipt};
+use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 use thiserror::Error;
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, Serialize, Deserialize)]
 pub enum ReceiptError {
     #[error("invalid allocation ID: {received_allocation_id}")]
     InvalidAllocationID { received_allocation_id: Address },
@@ -36,7 +37,7 @@ pub enum ReceiptError {
 
 pub type ReceiptResult<T> = Result<T, ReceiptError>;
 pub type ReceiptCheckResults = HashMap<ReceiptCheck, Option<ReceiptResult<()>>>;
-#[derive(Hash, Eq, PartialEq, Debug, Clone, EnumString, Display)]
+#[derive(Hash, Eq, PartialEq, Debug, Clone, EnumString, Display, Serialize, Deserialize)]
 pub enum ReceiptCheck {
     CheckUnique,
     CheckAllocationId,

--- a/tap_core/src/tap_receipt/received_receipt.rs
+++ b/tap_core/src/tap_receipt/received_receipt.rs
@@ -13,6 +13,7 @@
 //! This module is useful for managing and tracking the state of received receipts, as well as
 //! their progress through various checks and stages of inclusion in RAV requests and received RAVs.
 
+use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 
 use super::{
@@ -26,7 +27,7 @@ use crate::{
     Error, Result,
 };
 
-#[derive(Eq, PartialEq, Debug, Clone, EnumString, Display)]
+#[derive(Eq, PartialEq, Debug, Clone, EnumString, Display, Serialize, Deserialize)]
 /// State of the contained receipt
 pub enum ReceiptState {
     /// Initial state, received with no checks started
@@ -45,7 +46,7 @@ pub enum ReceiptState {
     Complete,
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 
 /// Status of receipt relating to RAV inclusion
 pub enum RAVStatus {
@@ -57,7 +58,7 @@ pub enum RAVStatus {
     IncludedInReceived,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// Wrapper class for metadata and state of a received receipt
 pub struct ReceivedReceipt {
     /// An EIP712 signed receipt message


### PR DESCRIPTION
So that `ReceivedReceipt` instances can be easily stored in external storage.
Need this for the WIP integration into indexer-service-rs.