### PR TITLE
refactor(core)!: make ChecksAdapter return Result

### DIFF
--- a/tap_core/src/adapters/receipt_checks_adapter.rs
+++ b/tap_core/src/adapters/receipt_checks_adapter.rs
@@ -30,27 +30,40 @@ use ethereum_types::Address;
 
 #[async_trait]
 pub trait ReceiptChecksAdapter {
+    /// Defines the user-specified error type.
+    ///
+    /// This error type should implement the `Error` and `Debug` traits from the standard library.
+    /// Errors of this type are returned to the user when an operation fails.
+    type AdapterError: std::error::Error + std::fmt::Debug + Send + Sync + 'static;
+
     /// Checks if the given receipt is unique in the system.
     ///
     /// This method should be implemented to verify the uniqueness of a given receipt in your system. Keep in mind that
     /// the receipt likely will be in storage when this check is performed so the receipt id should be used to check
     /// for uniqueness.
-    async fn is_unique(&self, receipt: &EIP712SignedMessage<Receipt>, receipt_id: u64) -> bool;
+    async fn is_unique(
+        &self,
+        receipt: &EIP712SignedMessage<Receipt>,
+        receipt_id: u64,
+    ) -> Result<bool, Self::AdapterError>;
 
     /// Verifies if the allocation ID is valid.
     ///
     /// This method should be implemented to validate the given allocation ID is a valid allocation for the indexer. Valid is defined as
     /// an allocation ID that is owned by the indexer and still available for redeeming.
-    async fn is_valid_allocation_id(&self, allocation_id: Address) -> bool;
+    async fn is_valid_allocation_id(
+        &self,
+        allocation_id: Address,
+    ) -> Result<bool, Self::AdapterError>;
 
     /// Confirms the value of the receipt is valid for the given query ID.
     ///
     /// This method should be implemented to confirm the validity of the given value for a specific query ID.
-    async fn is_valid_value(&self, value: u128, query_id: u64) -> bool;
+    async fn is_valid_value(&self, value: u128, query_id: u64) -> Result<bool, Self::AdapterError>;
 
     /// Confirms the gateway ID is valid.
     ///
     /// This method should be implemented to validate the given gateway ID is one associated with a gateway the indexer considers valid.
     /// The provided gateway ID is the address of the gateway that is recovered from the signature of the receipt.
-    async fn is_valid_gateway_id(&self, gateway_id: Address) -> bool;
+    async fn is_valid_gateway_id(&self, gateway_id: Address) -> Result<bool, Self::AdapterError>;
 }

--- a/tap_core/src/adapters/test/receipt_checks_adapter_mock.rs
+++ b/tap_core/src/adapters/test/receipt_checks_adapter_mock.rs
@@ -8,12 +8,13 @@ use std::{
 
 use async_trait::async_trait;
 use ethereum_types::Address;
+use thiserror::Error;
 use tokio::sync::RwLock;
 
 use crate::{
     adapters::receipt_checks_adapter::ReceiptChecksAdapter,
     eip_712_signed_message::EIP712SignedMessage,
-    tap_receipt::{Receipt, ReceivedReceipt},
+    tap_receipt::{Receipt, ReceiptError, ReceivedReceipt},
 };
 
 pub struct ReceiptChecksAdapterMock {
@@ -21,6 +22,20 @@ pub struct ReceiptChecksAdapterMock {
     query_appraisals: Arc<RwLock<HashMap<u64, u128>>>,
     allocation_ids: Arc<RwLock<HashSet<Address>>>,
     gateway_ids: Arc<RwLock<HashSet<Address>>>,
+}
+
+#[derive(Debug, Error)]
+pub enum AdapterErrorMock {
+    #[error("something went wrong: {error}")]
+    AdapterError { error: String },
+}
+
+impl From<AdapterErrorMock> for ReceiptError {
+    fn from(val: AdapterErrorMock) -> Self {
+        ReceiptError::CheckFailedToComplete {
+            source_error_message: val.to_string(),
+        }
+    }
 }
 
 impl ReceiptChecksAdapterMock {
@@ -41,33 +56,42 @@ impl ReceiptChecksAdapterMock {
 
 #[async_trait]
 impl ReceiptChecksAdapter for ReceiptChecksAdapterMock {
-    async fn is_unique(&self, receipt: &EIP712SignedMessage<Receipt>, receipt_id: u64) -> bool {
+    type AdapterError = AdapterErrorMock;
+
+    async fn is_unique(
+        &self,
+        receipt: &EIP712SignedMessage<Receipt>,
+        receipt_id: u64,
+    ) -> Result<bool, Self::AdapterError> {
         let receipt_storage = self.receipt_storage.read().await;
-        receipt_storage
+        Ok(receipt_storage
             .iter()
             .all(|(stored_receipt_id, stored_receipt)| {
                 (stored_receipt.signed_receipt.message != receipt.message)
                     || *stored_receipt_id == receipt_id
-            })
+            }))
     }
 
-    async fn is_valid_allocation_id(&self, allocation_id: Address) -> bool {
+    async fn is_valid_allocation_id(
+        &self,
+        allocation_id: Address,
+    ) -> Result<bool, Self::AdapterError> {
         let allocation_ids = self.allocation_ids.read().await;
-        allocation_ids.contains(&allocation_id)
+        Ok(allocation_ids.contains(&allocation_id))
     }
 
-    async fn is_valid_value(&self, value: u128, query_id: u64) -> bool {
+    async fn is_valid_value(&self, value: u128, query_id: u64) -> Result<bool, Self::AdapterError> {
         let query_appraisals = self.query_appraisals.read().await;
         let appraised_value = query_appraisals.get(&query_id).unwrap();
 
         if value != *appraised_value {
-            return false;
+            return Ok(false);
         }
-        true
+        Ok(true)
     }
 
-    async fn is_valid_gateway_id(&self, gateway_id: Address) -> bool {
+    async fn is_valid_gateway_id(&self, gateway_id: Address) -> Result<bool, Self::AdapterError> {
         let gateway_ids = self.gateway_ids.read().await;
-        gateway_ids.contains(&gateway_id)
+        Ok(gateway_ids.contains(&gateway_id))
     }
 }

--- a/tap_core/src/adapters/test/receipt_checks_adapter_test.rs
+++ b/tap_core/src/adapters/test/receipt_checks_adapter_test.rs
@@ -98,25 +98,22 @@ mod receipt_checks_adapter_unit_test {
             .await
             .insert(unique_receipt_id, new_receipt.1.clone());
 
-        assert!(
-            receipt_checks_adapter
-                .is_unique(&new_receipt.1.signed_receipt, unique_receipt_id)
-                .await
-        );
-        assert!(
-            receipt_checks_adapter
-                .is_valid_allocation_id(new_receipt.1.signed_receipt.message.allocation_id)
-                .await
-        );
+        assert!(receipt_checks_adapter
+            .is_unique(&new_receipt.1.signed_receipt, unique_receipt_id)
+            .await
+            .unwrap());
+        assert!(receipt_checks_adapter
+            .is_valid_allocation_id(new_receipt.1.signed_receipt.message.allocation_id)
+            .await
+            .unwrap());
         // TODO: Add check when gateway_id is available from received receipt (issue: #56)
         // assert!(receipt_checks_adapter.is_valid_gateway_id(gateway_id));
-        assert!(
-            receipt_checks_adapter
-                .is_valid_value(
-                    new_receipt.1.signed_receipt.message.value,
-                    new_receipt.1.query_id
-                )
-                .await
-        );
+        assert!(receipt_checks_adapter
+            .is_valid_value(
+                new_receipt.1.signed_receipt.message.value,
+                new_receipt.1.query_id
+            )
+            .await
+            .unwrap());
     }
 }

--- a/tap_core/src/tap_receipt/receipt_auditor.rs
+++ b/tap_core/src/tap_receipt/receipt_auditor.rs
@@ -63,6 +63,9 @@ impl<EA: EscrowAdapter, RCA: ReceiptChecksAdapter> ReceiptAuditor<EA, RCA> {
             .receipt_checks_adapter
             .is_unique(signed_receipt, receipt_id)
             .await
+            .map_err(|e| ReceiptError::CheckFailedToComplete {
+                source_error_message: e.to_string(),
+            })?
         {
             return Err(ReceiptError::NonUniqueReceipt);
         }
@@ -77,6 +80,9 @@ impl<EA: EscrowAdapter, RCA: ReceiptChecksAdapter> ReceiptAuditor<EA, RCA> {
             .receipt_checks_adapter
             .is_valid_allocation_id(signed_receipt.message.allocation_id)
             .await
+            .map_err(|e| ReceiptError::CheckFailedToComplete {
+                source_error_message: e.to_string(),
+            })?
         {
             return Err(ReceiptError::InvalidAllocationID {
                 received_allocation_id: signed_receipt.message.allocation_id,
@@ -107,6 +113,9 @@ impl<EA: EscrowAdapter, RCA: ReceiptChecksAdapter> ReceiptAuditor<EA, RCA> {
             .receipt_checks_adapter
             .is_valid_value(signed_receipt.message.value, query_id)
             .await
+            .map_err(|e| ReceiptError::CheckFailedToComplete {
+                source_error_message: e.to_string(),
+            })?
         {
             return Err(ReceiptError::InvalidValue {
                 received_value: signed_receipt.message.value,
@@ -129,6 +138,9 @@ impl<EA: EscrowAdapter, RCA: ReceiptChecksAdapter> ReceiptAuditor<EA, RCA> {
             .receipt_checks_adapter
             .is_valid_gateway_id(receipt_signer_address)
             .await
+            .map_err(|e| ReceiptError::CheckFailedToComplete {
+                source_error_message: e.to_string(),
+            })?
         {
             return Err(ReceiptError::InvalidSignature {
                 source_error_message: format!(
@@ -171,6 +183,9 @@ impl<EA: EscrowAdapter, RCA: ReceiptChecksAdapter> ReceiptAuditor<EA, RCA> {
             .receipt_checks_adapter
             .is_valid_gateway_id(rav_signer_address)
             .await
+            .map_err(|err| Error::AdapterError {
+                source_error: anyhow::Error::new(err),
+            })?
         {
             return Err(Error::InvalidRecoveredSigner {
                 address: rav_signer_address,


### PR DESCRIPTION
BREAKING CHANGE: All ReceiptChecksAdapter trait method now return Result. Makes it possible to return Adapter errors besides just check failures.