### PR TITLE
fix: Update alloy to v0.3.2

### DIFF
--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -17,8 +17,8 @@ ethers-core = "2.0.0"
 ethers-contract = "2.0.0"
 ethers-contract-derive = "2.0.0"
 anyhow = "1"
-alloy-sol-types = { version = "0.3.1", features = ["eip712-serde"]}
-alloy-primitives = { version = "0.3.1", features = ["serde"]}
+alloy-sol-types = { version = "0.3.2", features = ["eip712-serde"]}
+alloy-primitives = { version = "0.3.2", features = ["serde"]}
 
 strum = "0.24.1"
 strum_macros = "0.24.3"

--- a/tap_integration_tests/Cargo.toml
+++ b/tap_integration_tests/Cargo.toml
@@ -19,8 +19,8 @@ futures = "0.3.28"
 anyhow = "1.0.71"
 tokio = "1.28.2"
 prometheus = "0.13.3"
-alloy-sol-types = { version = "0.3.1", features = ["eip712-serde"]}
-alloy-primitives = { version = "0.3.1", features = ["serde"]}
+alloy-sol-types = { version = "0.3.2", features = ["eip712-serde"]}
+alloy-primitives = { version = "0.3.2", features = ["serde"]}
 
 [[test]]
 name = "integration_tests"


### PR DESCRIPTION
Fixes a build issue with v0.3.1 and the rest of our dependencies. The previous PR didn't update in all the Cargo.toml files, and in particular not in core.