### PR TITLE
refactor(core): manager arg slice instead of vec

### DIFF
--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -81,7 +81,7 @@ impl<
         &self,
         signed_receipt: SignedReceipt,
         query_id: u64,
-        initial_checks: Vec<ReceiptCheck>,
+        initial_checks: &[ReceiptCheck],
     ) -> std::result::Result<(), Error> {
         let mut received_receipt =
             ReceivedReceipt::new(signed_receipt, query_id, &self.required_checks);
@@ -98,7 +98,7 @@ impl<
             })?;
 
         received_receipt
-            .perform_checks(initial_checks.as_slice(), receipt_id, &self.receipt_auditor)
+            .perform_checks(initial_checks, receipt_id, &self.receipt_auditor)
             .await?;
 
         self.receipt_storage_adapter

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -163,7 +163,7 @@ mod manager_unit_test {
         escrow_storage.write().await.insert(keys.1, 999999);
 
         assert!(manager
-            .verify_and_store_receipt(signed_receipt, query_id, initial_checks)
+            .verify_and_store_receipt(signed_receipt, query_id, initial_checks.as_slice())
             .await
             .is_ok());
     }
@@ -219,7 +219,7 @@ mod manager_unit_test {
                 .await
                 .insert(query_id, value);
             assert!(manager
-                .verify_and_store_receipt(signed_receipt, query_id, initial_checks.clone())
+                .verify_and_store_receipt(signed_receipt, query_id, initial_checks.as_slice())
                 .await
                 .is_ok());
         }
@@ -298,7 +298,7 @@ mod manager_unit_test {
                 .await
                 .insert(query_id, value);
             assert!(manager
-                .verify_and_store_receipt(signed_receipt, query_id, initial_checks.clone())
+                .verify_and_store_receipt(signed_receipt, query_id, initial_checks.as_slice())
                 .await
                 .is_ok());
             expected_accumulated_value += value;
@@ -347,7 +347,7 @@ mod manager_unit_test {
                 .await
                 .insert(query_id, value);
             assert!(manager
-                .verify_and_store_receipt(signed_receipt, query_id, initial_checks.clone())
+                .verify_and_store_receipt(signed_receipt, query_id, initial_checks.as_slice())
                 .await
                 .is_ok());
             expected_accumulated_value += value;
@@ -431,7 +431,7 @@ mod manager_unit_test {
                 .await
                 .insert(query_id, value);
             assert!(manager
-                .verify_and_store_receipt(signed_receipt, query_id, initial_checks.clone())
+                .verify_and_store_receipt(signed_receipt, query_id, initial_checks.as_slice())
                 .await
                 .is_ok());
             expected_accumulated_value += value;
@@ -488,7 +488,7 @@ mod manager_unit_test {
                 .await
                 .insert(query_id, value);
             assert!(manager
-                .verify_and_store_receipt(signed_receipt, query_id, initial_checks.clone())
+                .verify_and_store_receipt(signed_receipt, query_id, initial_checks.as_slice())
                 .await
                 .is_ok());
             expected_accumulated_value += value;

--- a/tap_integration_tests/tests/indexer_mock/mod.rs
+++ b/tap_integration_tests/tests/indexer_mock/mod.rs
@@ -120,7 +120,7 @@ impl<
     ) -> Result<(), jsonrpsee::types::ErrorObjectOwned> {
         let verify_result = match self
             .manager
-            .verify_and_store_receipt(receipt, request_id, self.initial_checks.clone())
+            .verify_and_store_receipt(receipt, request_id, self.initial_checks.as_slice())
             .await
         {
             Ok(_) => Ok(()),


### PR DESCRIPTION
BREAKING CHANGE:
`tap_core::tap_manager::manager::Manager::verify_and_store_receipt` now takes a slice of initial_checks instead of a Vec.