### PR TITLE
feat(core): enable user custom check flows

### DIFF
--- a/tap_core/src/tap_receipt/received_receipt.rs
+++ b/tap_core/src/tap_receipt/received_receipt.rs
@@ -208,7 +208,13 @@ impl ReceivedReceipt {
         self.update_state();
     }
 
-    pub(crate) fn update_check(
+    /// Update the state of a receipt check, should be called when a check is completed.
+    ///
+    /// Note: the function is public to let library users update the state of a check if they are using a different
+    ///     checking mechanism than the one provided by the library, such as running batch checks before a RAV request.
+    ///
+    /// Todo: consider refactoring to make this function private again.
+    pub fn update_check(
         &mut self,
         check: &ReceiptCheck,
         result: Option<super::ReceiptResult<()>>,


### PR DESCRIPTION
Split `create_rav_request` to let the user execute checks entirely themselves. This enables running batched checks before a RAV request.

This kinda breaks the encapsulation, but I couldn't figure out anything better that fits my needs in https://github.com/graphops/indexer-service-rs for now...