### PR TITLE
refactor(core): collect runs batched checks

### DIFF
--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -151,7 +151,7 @@ impl<
     ///
     /// Returns [`Error::AdapterError`] if there are any errors while retrieving last RAV or removing receipts
     ///
-    pub async fn remove_obsolete_receipts(&self) -> Result<(), Error> {
+    pub async fn remove_obsolete_receipts(&mut self) -> Result<(), Error> {
         match self.get_previous_rav().await? {
             Some(last_rav) => {
                 self.receipt_storage_adapter

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -240,10 +240,12 @@ impl<
             received_receipts.into_iter().map(|e| e.1).collect();
 
         for check in self.required_checks.iter() {
-            self.receipt_auditor
-                .check_bunch(check, &mut received_receipts)
-                .await
-                .unwrap();
+            ReceivedReceipt::perform_check_batch(
+                &mut received_receipts,
+                check,
+                &self.receipt_auditor,
+            )
+            .await?;
         }
 
         for received_receipt in received_receipts {

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -151,7 +151,7 @@ impl<
     ///
     /// Returns [`Error::AdapterError`] if there are any errors while retrieving last RAV or removing receipts
     ///
-    pub async fn remove_obsolete_receipts(&mut self) -> Result<(), Error> {
+    pub async fn remove_obsolete_receipts(&self) -> Result<(), Error> {
         match self.get_previous_rav().await? {
             Some(last_rav) => {
                 self.receipt_storage_adapter

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -236,10 +236,17 @@ impl<
         let mut accepted_signed_receipts = Vec::<SignedReceipt>::new();
         let mut failed_signed_receipts = Vec::<SignedReceipt>::new();
 
-        for (receipt_id, mut received_receipt) in received_receipts {
-            received_receipt
-                .finalize_receipt_checks(receipt_id, &self.receipt_auditor)
-                .await?;
+        let mut received_receipts: Vec<ReceivedReceipt> =
+            received_receipts.into_iter().map(|e| e.1).collect();
+
+        for check in self.required_checks.iter() {
+            self.receipt_auditor
+                .check_bunch(check, &mut received_receipts)
+                .await
+                .unwrap();
+        }
+
+        for received_receipt in received_receipts {
             if received_receipt.is_accepted() {
                 accepted_signed_receipts.push(received_receipt.signed_receipt);
             } else {

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -404,7 +404,7 @@ mod manager_unit_test {
         // give receipt 5 second variance for min start time
         let starting_min_timestamp = get_current_timestamp_u64_ns().unwrap() - 500000000;
 
-        let manager = Manager::new(
+        let mut manager = Manager::new(
             domain_separator.clone(),
             escrow_adapter,
             receipt_checks_adapter,

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -404,7 +404,7 @@ mod manager_unit_test {
         // give receipt 5 second variance for min start time
         let starting_min_timestamp = get_current_timestamp_u64_ns().unwrap() - 500000000;
 
-        let mut manager = Manager::new(
+        let manager = Manager::new(
             domain_separator.clone(),
             escrow_adapter,
             receipt_checks_adapter,

--- a/tap_core/src/tap_receipt/received_receipt.rs
+++ b/tap_core/src/tap_receipt/received_receipt.rs
@@ -293,7 +293,7 @@ impl ReceivedReceipt {
     }
 
     /// Updates receieved receipt state based on internal values, should be called anytime internal state changes
-    fn update_state(&mut self) {
+    pub(crate) fn update_state(&mut self) {
         let mut next_state = self.state.clone();
         match self.state {
             ReceiptState::Received => {
@@ -357,14 +357,14 @@ impl ReceivedReceipt {
         ReceiptState::AwaitingReserveEscrow
     }
 
-    fn escrow_reserve_attempt_completed(&self) -> bool {
+    pub(crate) fn escrow_reserve_attempt_completed(&self) -> bool {
         if let Some(escrow_reserve_attempt) = &self.escrow_reserved {
             return escrow_reserve_attempt.is_some();
         }
         false
     }
 
-    fn escrow_reserve_attempt_required(&self) -> bool {
+    pub(crate) fn escrow_reserve_attempt_required(&self) -> bool {
         self.escrow_reserved.is_some()
     }
 


### PR DESCRIPTION
The checks are specifically made to check the receipts that are to be aggregated only in their own context. Helps for uniqueness checks for example, where we avoid calling the storage backend and only check that the collected receipts are unique.

In terms of the public API, this should be a cleaner solution than #179 . The implementation itself is not super clean though. A deeper refactor of tap_core may help make this a bit less hacky.