### PR TITLE
fix: mutable manager.remove_obsolete_receipts

### DIFF
--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -151,7 +151,7 @@ impl<
     ///
     /// Returns [`Error::AdapterError`] if there are any errors while retrieving last RAV or removing receipts
     ///
-    pub async fn remove_obsolete_receipts(&mut self) -> Result<(), Error> {
+    pub async fn remove_obsolete_receipts(&self) -> Result<(), Error> {
         match self.get_previous_rav().await? {
             Some(last_rav) => {
                 self.receipt_storage_adapter

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -404,7 +404,7 @@ mod manager_unit_test {
         // give receipt 5 second variance for min start time
         let starting_min_timestamp = get_current_timestamp_u64_ns().unwrap() - 500000000;
 
-        let mut manager = Manager::new(
+        let manager = Manager::new(
             domain_separator.clone(),
             escrow_adapter,
             receipt_checks_adapter,


### PR DESCRIPTION
Remove unnecessary mutability that makes usage a little bit harder.