### PR TITLE
feat!: create_rav_request() returns invalid ReceivedReceipt

### DIFF
--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -216,7 +216,7 @@ impl<
         &self,
         timestamp_buffer_ns: u64,
         min_timestamp_ns: u64,
-    ) -> Result<(Vec<SignedReceipt>, Vec<SignedReceipt>), Error> {
+    ) -> Result<(Vec<SignedReceipt>, Vec<ReceivedReceipt>), Error> {
         let max_timestamp_ns = crate::get_current_timestamp_u64_ns()? - timestamp_buffer_ns;
 
         if min_timestamp_ns > max_timestamp_ns {
@@ -234,7 +234,7 @@ impl<
             })?;
 
         let mut accepted_signed_receipts = Vec::<SignedReceipt>::new();
-        let mut failed_signed_receipts = Vec::<SignedReceipt>::new();
+        let mut failed_signed_receipts = Vec::<ReceivedReceipt>::new();
 
         let mut received_receipts: Vec<ReceivedReceipt> =
             received_receipts.into_iter().map(|e| e.1).collect();
@@ -252,7 +252,7 @@ impl<
             if received_receipt.is_accepted() {
                 accepted_signed_receipts.push(received_receipt.signed_receipt);
             } else {
-                failed_signed_receipts.push(received_receipt.signed_receipt);
+                failed_signed_receipts.push(received_receipt);
             }
         }
 

--- a/tap_core/src/tap_manager/rav_request.rs
+++ b/tap_core/src/tap_manager/rav_request.rs
@@ -4,13 +4,13 @@
 use serde::{Deserialize, Serialize};
 
 use super::{SignedRAV, SignedReceipt};
-use crate::receipt_aggregate_voucher::ReceiptAggregateVoucher;
+use crate::{receipt_aggregate_voucher::ReceiptAggregateVoucher, tap_receipt::ReceivedReceipt};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 
 pub struct RAVRequest {
     pub valid_receipts: Vec<SignedReceipt>,
     pub previous_rav: Option<SignedRAV>,
-    pub invalid_receipts: Vec<SignedReceipt>,
+    pub invalid_receipts: Vec<ReceivedReceipt>,
     pub expected_rav: ReceiptAggregateVoucher,
 }


### PR DESCRIPTION
Helps the user determine why the receipts failed, because ReceivedReceipt contains the status of checks.