### PR TITLE
refactor!: use typestate for receivedreceipt

### DIFF
--- a/tap_core/src/adapters/mock/receipt_checks_adapter_mock.rs
+++ b/tap_core/src/adapters/mock/receipt_checks_adapter_mock.rs
@@ -67,7 +67,7 @@ impl ReceiptChecksAdapter for ReceiptChecksAdapterMock {
         Ok(receipt_storage
             .iter()
             .all(|(stored_receipt_id, stored_receipt)| {
-                (stored_receipt.signed_receipt.message != receipt.message)
+                (stored_receipt.signed_receipt().message != receipt.message)
                     || *stored_receipt_id == receipt_id
             }))
     }

--- a/tap_core/src/adapters/test/receipt_checks_adapter_test.rs
+++ b/tap_core/src/adapters/test/receipt_checks_adapter_test.rs
@@ -116,7 +116,7 @@ mod receipt_checks_adapter_unit_test {
             .insert(unique_receipt_id, new_receipt.1.clone());
 
         assert!(receipt_checks_adapter
-            .is_unique(&new_receipt.1.signed_receipt(), unique_receipt_id)
+            .is_unique(new_receipt.1.signed_receipt(), unique_receipt_id)
             .await
             .unwrap());
         assert!(receipt_checks_adapter

--- a/tap_core/src/adapters/test/receipt_checks_adapter_test.rs
+++ b/tap_core/src/adapters/test/receipt_checks_adapter_test.rs
@@ -116,19 +116,19 @@ mod receipt_checks_adapter_unit_test {
             .insert(unique_receipt_id, new_receipt.1.clone());
 
         assert!(receipt_checks_adapter
-            .is_unique(&new_receipt.1.signed_receipt, unique_receipt_id)
+            .is_unique(&new_receipt.1.signed_receipt(), unique_receipt_id)
             .await
             .unwrap());
         assert!(receipt_checks_adapter
-            .is_valid_allocation_id(new_receipt.1.signed_receipt.message.allocation_id)
+            .is_valid_allocation_id(new_receipt.1.signed_receipt().message.allocation_id)
             .await
             .unwrap());
         // TODO: Add check when sender_id is available from received receipt (issue: #56)
         // assert!(receipt_checks_adapter.is_valid_sender_id(sender_id));
         assert!(receipt_checks_adapter
             .is_valid_value(
-                new_receipt.1.signed_receipt.message.value,
-                new_receipt.1.query_id
+                new_receipt.1.signed_receipt().message.value,
+                new_receipt.1.query_id()
             )
             .await
             .unwrap());

--- a/tap_core/src/adapters/test/receipt_storage_adapter_test.rs
+++ b/tap_core/src/adapters/test/receipt_storage_adapter_test.rs
@@ -20,9 +20,10 @@ mod receipt_storage_adapter_unit_test {
         receipt_storage_adapter::ReceiptStore,
         receipt_storage_adapter_mock::ReceiptStorageAdapterMock,
     };
+    use crate::tap_receipt::ReceivedReceipt;
     use crate::{
         eip_712_signed_message::EIP712SignedMessage, tap_receipt::get_full_list_of_checks,
-        tap_receipt::Receipt, tap_receipt::ReceivedReceipt,
+        tap_receipt::Receipt,
     };
 
     #[fixture]
@@ -135,7 +136,7 @@ mod receipt_storage_adapter_unit_test {
                     .await
                     .unwrap(),
             );
-            receipt_timestamps.push(received_receipt.signed_receipt.message.timestamp_ns)
+            receipt_timestamps.push(received_receipt.signed_receipt().message.timestamp_ns)
         }
 
         // Retreive receipts with timestamp
@@ -241,12 +242,12 @@ mod receipt_storage_adapter_unit_test {
         for (elem_trun, expected_timestamp) in receipts_truncated.iter().zip(expected.iter()) {
             // Check timestamps
             assert_eq!(
-                elem_trun.1.signed_receipt.message.timestamp_ns,
+                elem_trun.1.signed_receipt().message.timestamp_ns,
                 *expected_timestamp
             );
 
             // Check that the IDs are fine
-            assert_eq!(elem_trun.0, elem_trun.1.query_id);
+            assert_eq!(elem_trun.0, elem_trun.1.query_id());
         }
     }
 }

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -12,7 +12,10 @@ use crate::{
         receipt_storage_adapter::{ReceiptRead, ReceiptStore},
     },
     receipt_aggregate_voucher::ReceiptAggregateVoucher,
-    tap_receipt::{ReceiptAuditor, ReceiptCheck, ReceivedReceipt},
+    tap_receipt::{
+        Failed, ReceiptAuditor, ReceiptCheck, ReceiptWithId, ReceiptWithState, ReceivedReceipt,
+        Reserved, ResultReceipt, StatefulVec,
+    },
     Error,
 };
 
@@ -122,7 +125,13 @@ where
         timestamp_buffer_ns: u64,
         min_timestamp_ns: u64,
         limit: Option<u64>,
-    ) -> Result<(Vec<SignedReceipt>, Vec<ReceivedReceipt>), Error> {
+    ) -> Result<
+        (
+            Vec<ReceiptWithState<Reserved>>,
+            Vec<ReceiptWithState<Failed>>,
+        ),
+        Error,
+    > {
         let max_timestamp_ns = crate::get_current_timestamp_u64_ns()? - timestamp_buffer_ns;
 
         if min_timestamp_ns > max_timestamp_ns {
@@ -139,30 +148,38 @@ where
                 source_error: anyhow::Error::new(err),
             })?;
 
-        let mut accepted_signed_receipts = Vec::<SignedReceipt>::new();
-        let mut failed_signed_receipts = Vec::<ReceivedReceipt>::new();
+        let StatefulVec {
+            checking_receipts,
+            mut awaiting_reserve_receipts,
+            mut failed_receipts,
+            mut reserved_receipts,
+        } = received_receipts.into();
 
-        let mut received_receipts: Vec<ReceivedReceipt> =
-            received_receipts.into_iter().map(|e| e.1).collect();
+        for received_receipt in checking_receipts {
+            let ReceiptWithId {
+                receipt,
+                receipt_id,
+            } = received_receipt;
+            let receipt = receipt
+                .finalize_receipt_checks(receipt_id, &self.receipt_auditor)
+                .await?;
 
-        for check in self.required_checks.iter() {
-            ReceivedReceipt::perform_check_batch(
-                &mut received_receipts,
-                check,
-                &self.receipt_auditor,
-            )
-            .await?;
+            match receipt {
+                ResultReceipt::Success(checked) => awaiting_reserve_receipts.push(checked),
+                ResultReceipt::Failed(failed) => failed_receipts.push(failed),
+            }
         }
-
-        for received_receipt in received_receipts {
-            if received_receipt.is_accepted() {
-                accepted_signed_receipts.push(received_receipt.signed_receipt);
-            } else {
-                failed_signed_receipts.push(received_receipt);
+        for checked in awaiting_reserve_receipts {
+            match checked
+                .check_and_reserve_escrow(&self.receipt_auditor)
+                .await
+            {
+                ResultReceipt::Success(reserved) => reserved_receipts.push(reserved),
+                ResultReceipt::Failed(failed) => failed_receipts.push(failed),
             }
         }
 
-        Ok((accepted_signed_receipts, failed_signed_receipts))
+        Ok((reserved_receipts, failed_receipts))
     }
 }
 
@@ -203,6 +220,10 @@ where
         self.receipt_auditor
             .update_min_timestamp_ns(expected_rav.timestamp_ns)
             .await;
+        let valid_receipts = valid_receipts
+            .into_iter()
+            .map(|rx_receipt| rx_receipt.signed_receipt())
+            .collect::<Vec<_>>();
 
         Ok(RAVRequest {
             valid_receipts,
@@ -213,14 +234,22 @@ where
     }
 
     fn generate_expected_rav(
-        receipts: &[SignedReceipt],
+        receipts: &[ReceiptWithState<Reserved>],
         previous_rav: Option<SignedRAV>,
     ) -> Result<ReceiptAggregateVoucher, Error> {
         if receipts.is_empty() {
             return Err(Error::NoValidReceiptsForRAVRequest);
         }
-        let allocation_id = receipts[0].message.allocation_id;
-        ReceiptAggregateVoucher::aggregate_receipts(allocation_id, receipts, previous_rav)
+        let allocation_id = receipts[0].signed_receipt().message.allocation_id;
+        let receipts = receipts
+            .iter()
+            .map(|rx_receipt| rx_receipt.signed_receipt())
+            .collect::<Vec<_>>();
+        ReceiptAggregateVoucher::aggregate_receipts(
+            allocation_id,
+            receipts.as_slice(),
+            previous_rav,
+        )
     }
 }
 
@@ -291,9 +320,11 @@ where
                 source_error: anyhow::Error::new(err),
             })?;
 
-        received_receipt
-            .perform_checks(initial_checks, receipt_id, &self.receipt_auditor)
-            .await?;
+        if let ReceivedReceipt::Checking(received_receipt) = &mut received_receipt {
+            received_receipt
+                .perform_checks(initial_checks, receipt_id, &self.receipt_auditor)
+                .await;
+        }
 
         self.receipt_storage_adapter
             .update_receipt_by_id(receipt_id, received_receipt)

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -13,8 +13,8 @@ use crate::{
     },
     receipt_aggregate_voucher::ReceiptAggregateVoucher,
     tap_receipt::{
-        Failed, ReceiptAuditor, ReceiptCheck, ReceiptWithId, ReceiptWithState, ReceivedReceipt,
-        Reserved, SplittedReceiptWithState,
+        CategorizedReceiptsWithState, Failed, ReceiptAuditor, ReceiptCheck, ReceiptWithId,
+        ReceiptWithState, ReceivedReceipt, Reserved,
     },
     Error,
 };
@@ -148,7 +148,7 @@ where
                 source_error: anyhow::Error::new(err),
             })?;
 
-        let SplittedReceiptWithState {
+        let CategorizedReceiptsWithState {
             checking_receipts,
             mut awaiting_reserve_receipts,
             mut failed_receipts,

--- a/tap_core/src/tap_manager/rav_request.rs
+++ b/tap_core/src/tap_manager/rav_request.rs
@@ -4,13 +4,16 @@
 use serde::{Deserialize, Serialize};
 
 use super::{SignedRAV, SignedReceipt};
-use crate::{receipt_aggregate_voucher::ReceiptAggregateVoucher, tap_receipt::ReceivedReceipt};
+use crate::{
+    receipt_aggregate_voucher::ReceiptAggregateVoucher,
+    tap_receipt::{Failed, ReceiptWithState},
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 
 pub struct RAVRequest {
     pub valid_receipts: Vec<SignedReceipt>,
     pub previous_rav: Option<SignedRAV>,
-    pub invalid_receipts: Vec<ReceivedReceipt>,
+    pub invalid_receipts: Vec<ReceiptWithState<Failed>>,
     pub expected_rav: ReceiptAggregateVoucher,
 }

--- a/tap_core/src/tap_receipt/mod.rs
+++ b/tap_core/src/tap_receipt/mod.rs
@@ -9,7 +9,11 @@ use std::collections::HashMap;
 use alloy_primitives::Address;
 pub use receipt::Receipt;
 pub use receipt_auditor::ReceiptAuditor;
-pub use received_receipt::{RAVStatus, ReceiptState, ReceivedReceipt};
+pub use received_receipt::{
+    AwaitingReserve, Checking, Failed, ReceiptState, ReceiptWithId, ReceiptWithState,
+    ReceivedReceipt, Reserved, ResultReceipt, StatefulVec,
+};
+
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 use thiserror::Error;
@@ -44,7 +48,6 @@ pub enum ReceiptCheck {
     CheckTimestamp,
     CheckValue,
     CheckSignature,
-    CheckAndReserveEscrow,
 }
 
 pub fn get_full_list_of_receipt_check_results() -> ReceiptCheckResults {
@@ -54,7 +57,6 @@ pub fn get_full_list_of_receipt_check_results() -> ReceiptCheckResults {
     all_checks_list.insert(ReceiptCheck::CheckTimestamp, None);
     all_checks_list.insert(ReceiptCheck::CheckValue, None);
     all_checks_list.insert(ReceiptCheck::CheckSignature, None);
-    all_checks_list.insert(ReceiptCheck::CheckAndReserveEscrow, None);
 
     all_checks_list
 }
@@ -66,7 +68,6 @@ pub fn get_full_list_of_checks() -> Vec<ReceiptCheck> {
         ReceiptCheck::CheckTimestamp,
         ReceiptCheck::CheckValue,
         ReceiptCheck::CheckSignature,
-        ReceiptCheck::CheckAndReserveEscrow,
     ]
 }
 

--- a/tap_core/src/tap_receipt/mod.rs
+++ b/tap_core/src/tap_receipt/mod.rs
@@ -11,7 +11,7 @@ pub use receipt::Receipt;
 pub use receipt_auditor::ReceiptAuditor;
 pub use received_receipt::{
     AwaitingReserve, Checking, Failed, ReceiptState, ReceiptWithId, ReceiptWithState,
-    ReceivedReceipt, Reserved, ResultReceipt, StatefulVec,
+    ReceivedReceipt, Reserved, ResultReceipt, SplittedReceiptWithState,
 };
 
 use serde::{Deserialize, Serialize};

--- a/tap_core/src/tap_receipt/mod.rs
+++ b/tap_core/src/tap_receipt/mod.rs
@@ -10,8 +10,8 @@ use alloy_primitives::Address;
 pub use receipt::Receipt;
 pub use receipt_auditor::ReceiptAuditor;
 pub use received_receipt::{
-    AwaitingReserve, Checking, Failed, ReceiptState, ReceiptWithId, ReceiptWithState,
-    ReceivedReceipt, Reserved, ResultReceipt, SplittedReceiptWithState,
+    AwaitingReserve, CategorizedReceiptsWithState, Checking, Failed, ReceiptState, ReceiptWithId,
+    ReceiptWithState, ReceivedReceipt, Reserved, ResultReceipt,
 };
 
 use serde::{Deserialize, Serialize};

--- a/tap_core/src/tap_receipt/received_receipt.rs
+++ b/tap_core/src/tap_receipt/received_receipt.rs
@@ -96,7 +96,7 @@ where
     }
 }
 
-pub struct SplittedReceiptWithState {
+pub struct CategorizedReceiptsWithState {
     pub(crate) awaiting_reserve_receipts: Vec<ReceiptWithState<AwaitingReserve>>,
     pub(crate) checking_receipts: Vec<ReceiptWithId<Checking>>,
     pub(crate) failed_receipts: Vec<ReceiptWithState<Failed>>,
@@ -136,7 +136,7 @@ impl From<ReceiptWithState<Reserved>> for ReceivedReceipt {
     }
 }
 
-impl From<Vec<StoredReceipt>> for SplittedReceiptWithState {
+impl From<Vec<StoredReceipt>> for CategorizedReceiptsWithState {
     fn from(value: Vec<StoredReceipt>) -> Self {
         let mut awaiting_reserve_receipts = Vec::new();
         let mut checking_receipts = Vec::new();
@@ -398,7 +398,6 @@ impl<S> ReceiptWithState<S>
 where
     S: ReceiptState,
 {
-
     fn perform_state_changes_into<T>(self) -> ReceiptWithState<T>
     where
         T: ReceiptState,

--- a/tap_core/src/tap_receipt/received_receipt.rs
+++ b/tap_core/src/tap_receipt/received_receipt.rs
@@ -14,63 +14,142 @@
 //! their progress through various checks and stages of inclusion in RAV requests and received RAVs.
 
 use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumString};
 
-use super::{
-    receipt_auditor::ReceiptAuditor, Receipt, ReceiptCheck, ReceiptCheckResults, ReceiptError,
-};
+use super::{receipt_auditor::ReceiptAuditor, Receipt, ReceiptCheck, ReceiptCheckResults};
 use crate::{
-    adapters::{escrow_adapter::EscrowAdapter, receipt_checks_adapter::ReceiptChecksAdapter},
+    adapters::{
+        escrow_adapter::EscrowAdapter, receipt_checks_adapter::ReceiptChecksAdapter,
+        receipt_storage_adapter::StoredReceipt,
+    },
     eip_712_signed_message::EIP712SignedMessage,
     Error, Result,
 };
 
-#[derive(Eq, PartialEq, Debug, Clone, EnumString, Display, Serialize, Deserialize)]
-/// State of the contained receipt
-pub enum ReceiptState {
-    /// Initial state, received with no checks started
-    Received,
-    /// Checking in progress, no errors found
-    Checking,
-    /// Checks completed with at least one check resulting in an error
-    Failed,
-    /// Checks completed with all passed, awaiting escrow check and reserve
-    AwaitingReserveEscrow,
-    /// All checks completed with no errors found, escrow is reserved if requested by user
-    Accepted,
-    /// Receipt was added to a RAV request
-    IncludedInRAVRequest,
-    /// Receipt was included in received RAV
-    Complete,
-}
-
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
-
-/// Status of receipt relating to RAV inclusion
-pub enum RAVStatus {
-    /// Has not been included in a RAV request or received RAV
-    NotIncluded,
-    /// Has been added to a RAV request, but not a received RAV (awaiting a response)
-    IncludedInRequest,
-    /// A RAV has been received that included this receipt
-    IncludedInReceived,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-/// Wrapper class for metadata and state of a received receipt
-pub struct ReceivedReceipt {
-    /// An EIP712 signed receipt message
-    pub(crate) signed_receipt: EIP712SignedMessage<Receipt>,
-    /// A unique identifier for the query associated with the receipt
-    pub(crate) query_id: u64,
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Checking {
     /// A list of checks to be completed for the receipt, along with their current result
     pub(crate) checks: ReceiptCheckResults,
-    /// Escrow check and reserve, which is performed only after all other checks are complete. `Ok` result means escrow was reserved
-    pub(crate) escrow_reserved: Option<Option<std::result::Result<(), ReceiptError>>>,
-    /// The current RAV status of the receipt (e.g., not included, included in a request, or included in a received RAV)
-    pub(crate) rav_status: RAVStatus,
-    /// The current state of the receipt (e.g., received, checking, failed, accepted, etc.)
-    pub(crate) state: ReceiptState,
+}
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Failed;
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AwaitingReserve;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Reserved;
+
+pub trait ReceiptState {}
+impl ReceiptState for Checking {}
+impl ReceiptState for AwaitingReserve {}
+impl ReceiptState for Reserved {}
+impl ReceiptState for Failed {}
+
+#[derive(Clone)]
+pub enum ReceivedReceipt {
+    AwaitingReserve(ReceiptWithState<AwaitingReserve>),
+    Checking(ReceiptWithState<Checking>),
+    Failed(ReceiptWithState<Failed>),
+    Reserved(ReceiptWithState<Reserved>),
+}
+
+pub enum ResultReceipt<S>
+where
+    S: ReceiptState,
+{
+    Success(ReceiptWithState<S>),
+    Failed(ReceiptWithState<Failed>),
+}
+
+pub struct ReceiptWithId<T>
+where
+    T: ReceiptState,
+{
+    pub(crate) receipt_id: u64,
+    pub(crate) receipt: ReceiptWithState<T>,
+}
+
+impl<T> From<(u64, ReceiptWithState<T>)> for ReceiptWithId<T>
+where
+    T: ReceiptState,
+{
+    fn from((receipt_id, receipt): (u64, ReceiptWithState<T>)) -> ReceiptWithId<T> {
+        Self {
+            receipt_id,
+            receipt,
+        }
+    }
+}
+
+pub struct StatefulVec {
+    pub(crate) awaiting_reserve_receipts: Vec<ReceiptWithState<AwaitingReserve>>,
+    pub(crate) checking_receipts: Vec<ReceiptWithId<Checking>>,
+    pub(crate) failed_receipts: Vec<ReceiptWithState<Failed>>,
+    pub(crate) reserved_receipts: Vec<ReceiptWithState<Reserved>>,
+}
+
+impl ResultReceipt<AwaitingReserve> {
+    pub fn into_stateful(self) -> ReceivedReceipt {
+        match self {
+            ResultReceipt::Success(checked) => ReceivedReceipt::AwaitingReserve(checked),
+            ResultReceipt::Failed(failed) => ReceivedReceipt::Failed(failed),
+        }
+    }
+}
+
+impl ReceiptWithState<AwaitingReserve> {
+    pub fn into_stateful(self) -> ReceivedReceipt {
+        ReceivedReceipt::AwaitingReserve(self)
+    }
+}
+
+impl ReceiptWithState<Checking> {
+    pub fn into_stateful(self) -> ReceivedReceipt {
+        ReceivedReceipt::Checking(self)
+    }
+}
+
+impl ReceiptWithState<Failed> {
+    pub fn into_stateful(self) -> ReceivedReceipt {
+        ReceivedReceipt::Failed(self)
+    }
+}
+
+impl ReceiptWithState<Reserved> {
+    pub fn into_stateful(self) -> ReceivedReceipt {
+        ReceivedReceipt::Reserved(self)
+    }
+}
+
+impl From<Vec<StoredReceipt>> for StatefulVec {
+    fn from(value: Vec<StoredReceipt>) -> Self {
+        let mut awaiting_reserve_receipts = Vec::new();
+        let mut checking_receipts = Vec::new();
+        let mut failed_receipts = Vec::new();
+        let mut reserved_receipts = Vec::new();
+
+        for stored_receipt in value {
+            let StoredReceipt {
+                receipt_id,
+                receipt,
+            } = stored_receipt;
+            match receipt {
+                ReceivedReceipt::AwaitingReserve(checked) => {
+                    awaiting_reserve_receipts.push(checked)
+                }
+                ReceivedReceipt::Checking(checking) => {
+                    checking_receipts.push((receipt_id, checking).into())
+                }
+                ReceivedReceipt::Failed(failed) => failed_receipts.push(failed),
+                ReceivedReceipt::Reserved(reserved) => reserved_receipts.push(reserved),
+            }
+        }
+        Self {
+            awaiting_reserve_receipts,
+            checking_receipts,
+            failed_receipts,
+            reserved_receipts,
+        }
+    }
 }
 
 impl ReceivedReceipt {
@@ -80,21 +159,67 @@ impl ReceivedReceipt {
         query_id: u64,
         required_checks: &[ReceiptCheck],
     ) -> Self {
-        let mut checks = Self::get_empty_required_checks_hashmap(required_checks);
-        let escrow_reserved = checks.remove(&ReceiptCheck::CheckAndReserveEscrow);
+        let checks = ReceiptWithState::get_empty_required_checks_hashmap(required_checks);
 
-        let mut received_receipt = Self {
+        let received_receipt = ReceiptWithState {
             signed_receipt,
             query_id,
-            checks,
-            escrow_reserved,
-            rav_status: RAVStatus::NotIncluded,
-            state: ReceiptState::Received,
+            state: Checking { checks },
         };
-        received_receipt.update_state();
-        received_receipt
+        received_receipt.into_stateful()
+    }
+    pub fn signed_receipt(&self) -> EIP712SignedMessage<Receipt> {
+        match self {
+            ReceivedReceipt::AwaitingReserve(ReceiptWithState { signed_receipt, .. })
+            | ReceivedReceipt::Checking(ReceiptWithState { signed_receipt, .. })
+            | ReceivedReceipt::Failed(ReceiptWithState { signed_receipt, .. })
+            | ReceivedReceipt::Reserved(ReceiptWithState { signed_receipt, .. }) => {
+                signed_receipt.clone()
+            }
+        }
     }
 
+    pub fn query_id(&self) -> u64 {
+        match self {
+            ReceivedReceipt::AwaitingReserve(ReceiptWithState { query_id, .. })
+            | ReceivedReceipt::Checking(ReceiptWithState { query_id, .. })
+            | ReceivedReceipt::Failed(ReceiptWithState { query_id, .. })
+            | ReceivedReceipt::Reserved(ReceiptWithState { query_id, .. }) => *query_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Wrapper class for metadata and state of a received receipt
+pub struct ReceiptWithState<S>
+where
+    S: ReceiptState,
+{
+    /// An EIP712 signed receipt message
+    pub(crate) signed_receipt: EIP712SignedMessage<Receipt>,
+    /// A unique identifier for the query associated with the receipt
+    pub(crate) query_id: u64,
+    /// The current state of the receipt (e.g., received, checking, failed, accepted, etc.)
+    pub(crate) state: S,
+}
+
+impl ReceiptWithState<AwaitingReserve> {
+    pub async fn check_and_reserve_escrow<EA, RCA>(
+        self,
+        auditor: &ReceiptAuditor<EA, RCA>,
+    ) -> ResultReceipt<Reserved>
+    where
+        EA: EscrowAdapter,
+        RCA: ReceiptChecksAdapter,
+    {
+        match auditor.check_and_reserve_escrow(&self).await {
+            Ok(_) => ResultReceipt::Success(self.perform_state_changes(Reserved)),
+            Err(_) => ResultReceipt::Failed(self.perform_state_changes(Failed)),
+        }
+    }
+}
+
+impl ReceiptWithState<Checking> {
     /// Completes a single *incomplete* check and stores the result, *if the check already has a result it is skipped.*
     ///
     /// Returns `Err` only if unable to complete the check, returns `Ok` if the check was completed (*Important:* this is not the result of the check, just the result of _completing_ the check)
@@ -110,31 +235,11 @@ impl ReceivedReceipt {
         check: &ReceiptCheck,
         receipt_id: u64,
         receipt_auditor: &ReceiptAuditor<CA, RCA>,
-    ) -> crate::Result<()> {
-        match self.state {
-            ReceiptState::Checking | ReceiptState::Received => {
-                // Cannot do escrow check and reserve until all other checks are complete
-                if check == &ReceiptCheck::CheckAndReserveEscrow {
-                    return Err(crate::Error::InvalidStateForRequestedAction {
-                        state: self.state.to_string(),
-                    });
-                }
-            }
-            // All checks are valid in this state (although complete ones will be skipped)
-            ReceiptState::AwaitingReserveEscrow => {}
-
-            // If all checks are complete then checking is skipped
-            ReceiptState::Accepted
-            | ReceiptState::Complete
-            | ReceiptState::IncludedInRAVRequest
-            | ReceiptState::Failed => return Ok(()),
-        }
-
-        // All skipped checks return `Ok`
-        let mut result = Ok(());
+    ) {
         // Only perform check if it is incomplete
-        if !self.check_is_complete(check) {
-            result = self.update_check(
+        // Don't check if already failed
+        if !self.check_is_complete(check) && !self.any_check_resulted_in_error() {
+            let _ = self.update_check(
                 check,
                 Some(
                     receipt_auditor
@@ -143,8 +248,6 @@ impl ReceivedReceipt {
                 ),
             );
         }
-        self.update_state();
-        result
     }
 
     pub async fn perform_check_batch<CA: EscrowAdapter, RCA: ReceiptChecksAdapter>(
@@ -156,7 +259,6 @@ impl ReceivedReceipt {
 
         for (receipt, result) in batch.iter_mut().zip(results) {
             receipt.update_check(check, Some(result))?;
-            receipt.update_state();
         }
 
         Ok(())
@@ -177,27 +279,10 @@ impl ReceivedReceipt {
         checks: &[ReceiptCheck],
         receipt_id: u64,
         receipt_auditor: &ReceiptAuditor<CA, RCA>,
-    ) -> Result<()> {
-        let mut check_and_reserve_escrow_included = false;
+    ) {
         for check in checks {
-            if *check == ReceiptCheck::CheckAndReserveEscrow {
-                // if checks include check and reserve escrow it needs to be completed last
-                check_and_reserve_escrow_included = true;
-                continue;
-            }
-            self.perform_check(check, receipt_id, receipt_auditor)
-                .await?;
+            self.perform_check(check, receipt_id, receipt_auditor).await;
         }
-        if check_and_reserve_escrow_included && self.state != ReceiptState::Failed {
-            // CheckAndReserveEscrow is only performed after all other checks have passed
-            self.perform_check(
-                &ReceiptCheck::CheckAndReserveEscrow,
-                receipt_id,
-                receipt_auditor,
-            )
-            .await?;
-        }
-        Ok(())
     }
 
     /// Completes all remaining checks and stores the results
@@ -205,96 +290,28 @@ impl ReceivedReceipt {
     /// Returns `Err` only if unable to complete a check, returns `Ok` if no check failed to complete (*Important:* this is not the result of the check, just the result of _completing_ the check)
     ///
     pub async fn finalize_receipt_checks<CA: EscrowAdapter, RCA: ReceiptChecksAdapter>(
-        &mut self,
+        mut self,
         receipt_id: u64,
         receipt_auditor: &ReceiptAuditor<CA, RCA>,
-    ) -> Result<()> {
-        self.perform_checks(
-            self.incomplete_checks().as_slice(),
-            receipt_id,
-            receipt_auditor,
-        )
-        .await
-    }
+    ) -> Result<ResultReceipt<AwaitingReserve>> {
+        let incomplete_checks = self.incomplete_checks();
 
-    /// Update RAV status, should be called when receipt is included in RAV request and when RAV request is received
-    pub fn update_rav_status(&mut self, rav_status: RAVStatus) {
-        self.rav_status = rav_status;
-        self.update_state();
-    }
+        self.perform_checks(incomplete_checks.as_slice(), receipt_id, receipt_auditor)
+            .await;
 
-    pub(crate) fn update_check(
-        &mut self,
-        check: &ReceiptCheck,
-        result: Option<super::ReceiptResult<()>>,
-    ) -> Result<()> {
-        if check == &ReceiptCheck::CheckAndReserveEscrow {
-            return self.update_escrow_reserved_check(check, result);
-        }
-
-        if !self.checks.contains_key(check) {
-            return Err(Error::InvalidCheckError {
-                check_string: check.to_string(),
-            });
-        }
-
-        self.checks.insert(check.clone(), result);
-        Ok(())
-    }
-
-    fn update_escrow_reserved_check(
-        &mut self,
-        check: &ReceiptCheck,
-        result: Option<super::ReceiptResult<()>>,
-    ) -> Result<()> {
-        if !(self.state == ReceiptState::AwaitingReserveEscrow) {
-            return Err(Error::InvalidStateForRequestedAction {
-                state: self.state.to_string(),
-            });
-        }
-
-        if let Some(ref mut escrow_reserved_check) = self.escrow_reserved {
-            *escrow_reserved_check = result;
+        if self.any_check_resulted_in_error() {
+            let failed = self.perform_state_changes(Failed);
+            Ok(ResultReceipt::Failed(failed))
         } else {
-            return Err(crate::Error::InvalidCheckError {
-                check_string: check.to_string(),
-            });
+            let checked = self.perform_state_changes(AwaitingReserve);
+            Ok(ResultReceipt::Success(checked))
         }
-
-        self.update_state();
-        Ok(())
-    }
-
-    pub fn signed_receipt(&self) -> EIP712SignedMessage<Receipt> {
-        self.signed_receipt.clone()
-    }
-
-    pub fn query_id(&self) -> u64 {
-        self.query_id
-    }
-
-    /// Returns all checks that have not been completed
-    pub fn incomplete_checks(&self) -> Vec<ReceiptCheck> {
-        let mut incomplete_checks: Vec<ReceiptCheck> = self
-            .checks
-            .iter()
-            .filter_map(|(check, result)| {
-                if result.is_none() {
-                    Some((*check).clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if self.escrow_reserve_attempt_required() && !self.escrow_reserve_attempt_completed() {
-            incomplete_checks.push(ReceiptCheck::CheckAndReserveEscrow);
-        }
-        incomplete_checks
     }
 
     /// Returns all checks that completed with errors
     pub fn completed_checks_with_errors(&self) -> ReceiptCheckResults {
-        self.checks
+        self.state
+            .checks
             .iter()
             .filter_map(|(check, result)| {
                 if let Some(unwrapped_result) = result {
@@ -307,118 +324,52 @@ impl ReceivedReceipt {
             .collect()
     }
 
-    /// Updates receieved receipt state based on internal values, should be called anytime internal state changes
-    pub(crate) fn update_state(&mut self) {
-        let mut next_state = self.state.clone();
-        match self.state {
-            ReceiptState::Received => {
-                if self.checking_is_started() {
-                    next_state = self.get_state_of_checks();
+    /// Returns all checks that have not been completed
+    pub fn incomplete_checks(&self) -> Vec<ReceiptCheck> {
+        let incomplete_checks: Vec<ReceiptCheck> = self
+            .state
+            .checks
+            .iter()
+            .filter_map(|(check, result)| {
+                if result.is_none() {
+                    Some((*check).clone())
                 } else {
-                    next_state = ReceiptState::Received;
+                    None
                 }
-            }
-            ReceiptState::Checking => {
-                next_state = self.get_state_of_checks();
-            }
-            ReceiptState::AwaitingReserveEscrow => {
-                next_state = self.get_state_of_escrow_reserve();
-            }
-            ReceiptState::Failed => {} // currently no next state from Failed
-            ReceiptState::Accepted => {
-                if self.rav_status == RAVStatus::IncludedInRequest {
-                    next_state = ReceiptState::IncludedInRAVRequest;
-                }
-            }
-            ReceiptState::IncludedInRAVRequest => {
-                if self.rav_status == RAVStatus::IncludedInReceived {
-                    next_state = ReceiptState::Complete;
-                }
-            }
-            ReceiptState::Complete => {} // currently no next state from complete
-        }
-        self.state = next_state;
+            })
+            .collect();
+        incomplete_checks
     }
 
-    fn get_state_of_checks(&self) -> ReceiptState {
-        if self.checking_is_completed() && self.any_check_resulted_in_error() {
-            return ReceiptState::Failed;
-        }
-        if self.all_checks_passed() {
-            return self.get_state_of_escrow_reserve();
-        }
-        if self.checking_is_in_progress() {
-            return ReceiptState::Checking;
-        }
-        // Incase the function got called when checking was not started we can return to received state
-        ReceiptState::Received
-    }
-
-    fn get_state_of_escrow_reserve(&self) -> ReceiptState {
-        if !self.escrow_reserve_attempt_required() {
-            return ReceiptState::Accepted;
-        }
-        if self.escrow_reserve_attempt_completed() {
-            if let Some(Some(escrow_reserve_attempt_result)) = &self.escrow_reserved {
-                if escrow_reserve_attempt_result.is_err() {
-                    return ReceiptState::Failed;
-                }
-                if escrow_reserve_attempt_result.is_ok() {
-                    return ReceiptState::Accepted;
-                }
-            }
+    pub(crate) fn update_check(
+        &mut self,
+        check: &ReceiptCheck,
+        result: Option<super::ReceiptResult<()>>,
+    ) -> Result<()> {
+        if !self.state.checks.contains_key(check) {
+            return Err(Error::InvalidCheckError {
+                check_string: check.to_string(),
+            });
         }
 
-        ReceiptState::AwaitingReserveEscrow
+        self.state.checks.insert(check.clone(), result);
+        Ok(())
     }
 
-    pub(crate) fn escrow_reserve_attempt_completed(&self) -> bool {
-        if let Some(escrow_reserve_attempt) = &self.escrow_reserved {
-            return escrow_reserve_attempt.is_some();
-        }
-        false
-    }
-
-    pub(crate) fn escrow_reserve_attempt_required(&self) -> bool {
-        self.escrow_reserved.is_some()
-    }
-
-    fn checking_is_in_progress(&self) -> bool {
-        self.checking_is_started() && !self.checking_is_completed()
-    }
-
-    fn checking_is_started(&self) -> bool {
-        self.checks.iter().any(|(_, status)| status.is_some())
-    }
-
-    fn checking_is_completed(&self) -> bool {
-        !self.checks.iter().any(|(_, status)| status.is_none())
+    /// returns true `check` has a result, otherwise false
+    pub(crate) fn check_is_complete(&self, check: &ReceiptCheck) -> bool {
+        matches!(self.state.checks.get(check), Some(Some(_)))
     }
 
     fn any_check_resulted_in_error(&self) -> bool {
-        self.checks.iter().any(|(_, status)| match &status {
+        self.state.checks.iter().any(|(_, status)| match &status {
             Some(result) => result.is_err(),
             None => false,
         })
     }
 
-    fn all_checks_passed(&self) -> bool {
-        self.checking_is_completed() && !self.any_check_resulted_in_error()
-    }
-
-    /// returns true `check` has a result, otherwise false
-    fn check_is_complete(&self, check: &ReceiptCheck) -> bool {
-        matches!(self.checks.get(check), Some(Some(_)))
-    }
-
-    /// Returns true if all checks are complete and at least one failed
-    pub fn is_failed(&self) -> bool {
-        self.state == ReceiptState::Failed
-    }
-
-    /// Returns true if all checks are complete and all checks passed
-    pub fn is_accepted(&self) -> bool {
-        self.state == ReceiptState::Accepted
+    pub fn checking_is_complete(&self) -> bool {
+        self.state.checks.iter().all(|(_, status)| status.is_some())
     }
 
     fn get_empty_required_checks_hashmap(required_checks: &[ReceiptCheck]) -> ReceiptCheckResults {
@@ -426,5 +377,29 @@ impl ReceivedReceipt {
             .iter()
             .map(|check| (check.clone(), None))
             .collect()
+    }
+}
+
+impl<S> ReceiptWithState<S>
+where
+    S: ReceiptState,
+{
+    fn perform_state_changes<T>(self, new_state: T) -> ReceiptWithState<T>
+    where
+        T: ReceiptState,
+    {
+        ReceiptWithState {
+            signed_receipt: self.signed_receipt,
+            query_id: self.query_id,
+            state: new_state,
+        }
+    }
+
+    pub fn signed_receipt(&self) -> EIP712SignedMessage<Receipt> {
+        self.signed_receipt.clone()
+    }
+
+    pub fn query_id(&self) -> u64 {
+        self.query_id
     }
 }

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -209,7 +209,6 @@ fn required_checks() -> Vec<ReceiptCheck> {
         ReceiptCheck::CheckTimestamp,
         ReceiptCheck::CheckUnique,
         ReceiptCheck::CheckValue,
-        ReceiptCheck::CheckAndReserveEscrow,
     ]
 }
 
@@ -223,7 +222,6 @@ fn initial_checks() -> Vec<ReceiptCheck> {
         ReceiptCheck::CheckTimestamp,
         ReceiptCheck::CheckUnique,
         ReceiptCheck::CheckValue,
-        ReceiptCheck::CheckAndReserveEscrow,
     ]
 }
 


### PR DESCRIPTION
## New state machine
- Using typestate pattern for `ReceivedReceipt` state machine
- States are now enforced by compile time and don't need to be checked by tests
- Transitions consume the old value creating a new state
```mermaid
graph TD;
    Checking-->AwaitingReserve;
    AwaitingReserve-->Reserved;
    Checking-->Failed;
    AwaitingReserve-->Failed;
```
## Remove RAV status
- The manager was not using rav statuses
- Implementation in tap-agent was not using it
- Removed from tests

## Escrow check is now a state
- Escrow check was a special optional check (a ReceivedReceipt may or may not have the required check)
- Escrow reserve is now a mandatory state
- Must be executed after all checks have passed