### PR TITLE
feat(aggregator): Add support for multiple signers in input

### DIFF
--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -34,4 +34,5 @@ ruint = "1.10.1"
 
 [dev-dependencies]
 jsonrpsee = { version = "0.18.0", features = ["http-client", "jsonrpsee-core"] }
+rand = "0.8.5"
 rstest = "0.17.0"

--- a/tap_core/src/error.rs
+++ b/tap_core/src/error.rs
@@ -29,7 +29,7 @@ pub enum Error {
     WalletError(#[from] WalletError),
     #[error(transparent)]
     SignatureError(#[from] SignatureError),
-    #[error("Recovered sender address invalid{address}")]
+    #[error("Recovered sender address invalid {address}")]
     InvalidRecoveredSigner { address: Address },
     #[error("Received RAV does not match expexted RAV")]
     InvalidReceivedRAV {

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -958,9 +958,12 @@ async fn start_sender_aggregator(
         listener.local_addr()?.port()
     };
 
+    let accepted_addresses = HashSet::from([keys.1]);
+
     let (server_handle, socket_addr) = agg_server::run_server(
         http_port,
         keys.0,
+        accepted_addresses,
         domain_separator,
         http_request_size_limit,
         http_response_size_limit,


### PR DESCRIPTION
Lets the aggregator accept receipts or input RAVs that are signed with other keys.
Helpful with dealing with the transition when rotating keys, or making sure that we can accept receipts signed by other signing keys belonging to the same Sender (multiple locations with different keys for example).

Fixes #205