### PR TITLE
Gusinacio/tap agent integration

### DIFF
--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -24,7 +24,6 @@ strum = "0.24.1"
 strum_macros = "0.24.3"
 async-trait = "0.1.72"
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
-futures = "0.3.17"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_std"] }

--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -24,7 +24,6 @@ strum = "0.24.1"
 strum_macros = "0.24.3"
 async-trait = "0.1.72"
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
-typetag = "0.2.14"
 futures = "0.3.17"
 
 [dev-dependencies]

--- a/tap_core/src/adapters/escrow_adapter.rs
+++ b/tap_core/src/adapters/escrow_adapter.rs
@@ -53,4 +53,9 @@ pub trait EscrowAdapter {
         sender_id: Address,
         value: u128,
     ) -> Result<(), Self::AdapterError>;
+    
+    async fn verify_signer(
+        &self,
+        signer_address: Address
+    ) -> Result<bool, Self::AdapterError>;
 }

--- a/tap_core/src/adapters/escrow_adapter.rs
+++ b/tap_core/src/adapters/escrow_adapter.rs
@@ -53,9 +53,6 @@ pub trait EscrowAdapter {
         sender_id: Address,
         value: u128,
     ) -> Result<(), Self::AdapterError>;
-    
-    async fn verify_signer(
-        &self,
-        signer_address: Address
-    ) -> Result<bool, Self::AdapterError>;
+
+    async fn verify_signer(&self, signer_address: Address) -> Result<bool, Self::AdapterError>;
 }

--- a/tap_core/src/adapters/mock/executor_mock.rs
+++ b/tap_core/src/adapters/mock/executor_mock.rs
@@ -3,7 +3,7 @@
 
 use crate::adapters::escrow_adapter::EscrowAdapter;
 use crate::adapters::receipt_storage_adapter::{
-    safe_truncate_receipts, ReceiptRead, ReceiptStore, StoredReceipt,
+    safe_truncate_receipts, ReceiptDelete, ReceiptRead, ReceiptStore, StoredReceipt,
 };
 use crate::checks::TimestampCheck;
 use crate::tap_receipt::ReceivedReceipt;
@@ -139,6 +139,7 @@ impl RAVRead for ExecutorMock {
 #[async_trait]
 impl ReceiptStore for ExecutorMock {
     type AdapterError = AdapterErrorMock;
+
     async fn store_receipt(&self, receipt: ReceivedReceipt) -> Result<u64, Self::AdapterError> {
         let mut id_pointer = self.unique_id.write().unwrap();
         let id_previous = *id_pointer;
@@ -164,6 +165,12 @@ impl ReceiptStore for ExecutorMock {
         *self.unique_id.write().unwrap() += 1;
         Ok(())
     }
+}
+
+#[async_trait]
+impl ReceiptDelete for ExecutorMock {
+    type AdapterError = AdapterErrorMock;
+
     async fn remove_receipts_in_timestamp_range<R: RangeBounds<u64> + std::marker::Send>(
         &self,
         timestamp_ns: R,
@@ -175,7 +182,6 @@ impl ReceiptStore for ExecutorMock {
         Ok(())
     }
 }
-
 #[async_trait]
 impl ReceiptRead for ExecutorMock {
     type AdapterError = AdapterErrorMock;

--- a/tap_core/src/adapters/mock/executor_mock.rs
+++ b/tap_core/src/adapters/mock/executor_mock.rs
@@ -6,6 +6,7 @@ use crate::adapters::receipt_storage_adapter::{
     safe_truncate_receipts, ReceiptDelete, ReceiptRead, ReceiptStore, StoredReceipt,
 };
 use crate::checks::TimestampCheck;
+use crate::eip_712_signed_message::MessageId;
 use crate::tap_receipt::ReceivedReceipt;
 use crate::{
     adapters::rav_storage_adapter::{RAVRead, RAVStore},
@@ -18,7 +19,7 @@ use std::sync::RwLock;
 use std::{collections::HashMap, sync::Arc};
 
 pub type EscrowStorage = Arc<RwLock<HashMap<Address, u128>>>;
-pub type QueryAppraisals = Arc<RwLock<HashMap<u64, u128>>>;
+pub type QueryAppraisals = Arc<RwLock<HashMap<MessageId, u128>>>;
 pub type ReceiptStorage = Arc<RwLock<HashMap<u64, ReceivedReceipt>>>;
 pub type RAVStorage = Arc<RwLock<Option<SignedRAV>>>;
 

--- a/tap_core/src/adapters/mock/executor_mock.rs
+++ b/tap_core/src/adapters/mock/executor_mock.rs
@@ -148,23 +148,6 @@ impl ReceiptStore for ExecutorMock {
         *id_pointer += 1;
         Ok(id_previous)
     }
-    async fn update_receipt_by_id(
-        &self,
-        receipt_id: u64,
-        receipt: ReceivedReceipt,
-    ) -> Result<(), Self::AdapterError> {
-        let mut receipt_storage = self.receipt_storage.write().unwrap();
-
-        if !receipt_storage.contains_key(&receipt_id) {
-            return Err(AdapterErrorMock::AdapterError {
-                error: "Invalid receipt_id".to_owned(),
-            });
-        };
-
-        receipt_storage.insert(receipt_id, receipt);
-        *self.unique_id.write().unwrap() += 1;
-        Ok(())
-    }
 }
 
 #[async_trait]

--- a/tap_core/src/adapters/receipt_storage_adapter.rs
+++ b/tap_core/src/adapters/receipt_storage_adapter.rs
@@ -58,7 +58,15 @@ pub trait ReceiptStore {
         receipt_id: u64,
         receipt: ReceivedReceipt,
     ) -> Result<(), Self::AdapterError>;
+}
 
+#[async_trait]
+pub trait ReceiptDelete {
+    /// Defines the user-specified error type.
+    ///
+    /// This error type should implement the `Error` and `Debug` traits from the standard library.
+    /// Errors of this type are returned to the user when an operation fails.
+    type AdapterError: std::error::Error + std::fmt::Debug + Send + Sync + 'static;
     /// Removes all `ReceivedReceipts` within a specific timestamp range from the storage.
     ///
     /// This method should be implemented to remove all `ReceivedReceipts` within a specific timestamp

--- a/tap_core/src/adapters/receipt_storage_adapter.rs
+++ b/tap_core/src/adapters/receipt_storage_adapter.rs
@@ -47,17 +47,6 @@ pub trait ReceiptStore {
     /// It returns a unique receipt_id associated with the stored receipt. Any errors that occur during
     /// this process should be captured and returned as an `AdapterError`.
     async fn store_receipt(&self, receipt: ReceivedReceipt) -> Result<u64, Self::AdapterError>;
-
-    /// Updates a specific `ReceivedReceipt` identified by a unique receipt_id.
-    ///
-    /// This method should be implemented to update a specific `ReceivedReceipt` identified by a unique
-    /// receipt_id in your storage system. Any errors that occur during this process should be captured
-    /// and returned as an `AdapterError`.
-    async fn update_receipt_by_id(
-        &self,
-        receipt_id: u64,
-        receipt: ReceivedReceipt,
-    ) -> Result<(), Self::AdapterError>;
 }
 
 #[async_trait]

--- a/tap_core/src/checks/mod.rs
+++ b/tap_core/src/checks/mod.rs
@@ -4,7 +4,7 @@
 use crate::tap_receipt::{Checking, ReceiptError, ReceiptWithState};
 use std::sync::{Arc, RwLock};
 
-pub type ReceiptCheck = Arc<dyn Check>;
+pub type ReceiptCheck = Arc<dyn Check + Sync + Send>;
 
 pub type CheckResult = anyhow::Result<()>;
 

--- a/tap_core/src/checks/mod.rs
+++ b/tap_core/src/checks/mod.rs
@@ -2,11 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::tap_receipt::{Checking, ReceiptError, ReceiptWithState};
-use std::sync::{Arc, RwLock};
+use std::{
+    ops::Deref,
+    sync::{Arc, RwLock},
+};
 
 pub type ReceiptCheck = Arc<dyn Check + Sync + Send>;
 
 pub type CheckResult = anyhow::Result<()>;
+
+pub struct Checks(Arc<[ReceiptCheck]>);
+
+impl Checks {
+    pub fn new(checks: Vec<ReceiptCheck>) -> Self {
+        Self(checks.into())
+    }
+}
+
+impl Deref for Checks {
+    type Target = [ReceiptCheck];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
 
 #[async_trait::async_trait]
 pub trait Check {

--- a/tap_core/src/checks/mod.rs
+++ b/tap_core/src/checks/mod.rs
@@ -59,7 +59,7 @@ impl Check for TimestampCheck {
     async fn check(&self, receipt: &ReceiptWithState<Checking>) -> CheckResult {
         let min_timestamp_ns = *self.min_timestamp_ns.read().unwrap();
         let signed_receipt = receipt.signed_receipt();
-        if signed_receipt.message.timestamp_ns < min_timestamp_ns {
+        if signed_receipt.message.timestamp_ns <= min_timestamp_ns {
             return Err(ReceiptError::InvalidTimestamp {
                 received_timestamp: signed_receipt.message.timestamp_ns,
                 timestamp_min: min_timestamp_ns,

--- a/tap_core/src/checks/mod.rs
+++ b/tap_core/src/checks/mod.rs
@@ -182,7 +182,6 @@ pub mod mock {
                 .map_err(|e| ReceiptError::InvalidSignature {
                     source_error_message: e.to_string(),
                 })?;
-            println!("{:?}, {:?}", self.valid_signers, recovered_address);
             if !self.valid_signers.contains(&recovered_address) {
                 Err(ReceiptError::InvalidSignature {
                     source_error_message: "Invalid signer".to_string(),

--- a/tap_core/src/eip_712_signed_message.rs
+++ b/tap_core/src/eip_712_signed_message.rs
@@ -19,7 +19,7 @@ pub struct EIP712SignedMessage<M: SolStruct> {
     pub signature: Signature,
 }
 
-#[derive(Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash)]
 pub struct MessageId(pub [u8; 32]);
 
 impl<M: SolStruct> EIP712SignedMessage<M> {

--- a/tap_core/src/eip_712_signed_message.rs
+++ b/tap_core/src/eip_712_signed_message.rs
@@ -51,7 +51,8 @@ impl<M: SolStruct> EIP712SignedMessage<M> {
     /// Returns [`Error::InvalidSignature`] if the signature is not valid with provided `verifying_key`
     ///
     pub fn verify(&self, domain_separator: &Eip712Domain, expected_address: Address) -> Result<()> {
-        let recovery_message_hash = self.hash(domain_separator);
+        let recovery_message_hash: [u8; 32] =
+            self.message.eip712_signing_hash(domain_separator).into();
         let expected_address: [u8; 20] = expected_address.into();
 
         self.signature
@@ -61,11 +62,5 @@ impl<M: SolStruct> EIP712SignedMessage<M> {
 
     pub fn unique_hash(&self) -> MessageId {
         MessageId(self.message.eip712_hash_struct().into())
-    }
-
-    fn hash(&self, domain_separator: &Eip712Domain) -> [u8; 32] {
-        let recovery_message_hash: [u8; 32] =
-            self.message.eip712_signing_hash(domain_separator).into();
-        recovery_message_hash
     }
 }

--- a/tap_core/src/eip_712_signed_message.rs
+++ b/tap_core/src/eip_712_signed_message.rs
@@ -60,6 +60,7 @@ impl<M: SolStruct> EIP712SignedMessage<M> {
         Ok(())
     }
 
+    /// Use this a simple key for testing
     pub fn unique_hash(&self) -> MessageId {
         MessageId(self.message.eip712_hash_struct().into())
     }

--- a/tap_core/src/error.rs
+++ b/tap_core/src/error.rs
@@ -4,7 +4,7 @@
 //! Module containing Error type and Result typedef
 //!
 
-use crate::receipt_aggregate_voucher::ReceiptAggregateVoucher;
+use crate::{receipt_aggregate_voucher::ReceiptAggregateVoucher, tap_receipt::ReceiptError};
 use alloy_primitives::Address;
 use ethers::signers::WalletError;
 use ethers_core::types::SignatureError;
@@ -55,6 +55,9 @@ pub enum Error {
         min_timestamp_ns: u64,
         max_timestamp_ns: u64,
     },
+
+    #[error("Receipt error: {0}")]
+    ReceiptError(#[from] ReceiptError),
 }
 
 pub type Result<T> = StdResult<T, Error>;

--- a/tap_core/src/error.rs
+++ b/tap_core/src/error.rs
@@ -58,6 +58,9 @@ pub enum Error {
 
     #[error("Receipt error: {0}")]
     ReceiptError(#[from] ReceiptError),
+
+    #[error("Failed to check the signer: {0}")]
+    FailedToVerifySigner(String),
 }
 
 pub type Result<T> = StdResult<T, Error>;

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -289,8 +289,7 @@ where
 
         // perform checks
         if let ReceivedReceipt::Checking(received_receipt) = &mut received_receipt {
-            // received_receipt.perform_checks(&self.checks).await?;
-            received_receipt.perform_checks(&[]).await?;
+            received_receipt.perform_checks(&self.checks).await?;
         }
 
         // store the receipt

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -271,7 +271,7 @@ where
 
 impl<E> Manager<E>
 where
-    E: ReceiptStore + EscrowAdapter,
+    E: ReceiptStore,
 {
     /// Runs `initial_checks` on `signed_receipt` for initial verification, then stores received receipt.
     /// The provided `query_id` will be used as a key when chaecking query appraisal.

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -292,18 +292,8 @@ where
     ) -> std::result::Result<(), Error> {
         let mut received_receipt =
             ReceivedReceipt::new(signed_receipt, query_id, &self.required_checks);
-        // The receipt id is needed before `perform_checks` can be called on received receipt
-        // since it is needed for uniqueness check. Since the receipt_id is defined when it is stored
-        // This function first stores it, then checks it, then updates what was stored.
 
-        let receipt_id = self
-            .executor
-            .store_receipt(received_receipt.clone())
-            .await
-            .map_err(|err| Error::AdapterError {
-                source_error: anyhow::Error::new(err),
-            })?;
-
+        // perform checks
         if let ReceivedReceipt::Checking(received_receipt) = &mut received_receipt {
             received_receipt
                 .perform_checks(
@@ -316,8 +306,9 @@ where
                 .await;
         }
 
+        // store the receipt
         self.executor
-            .update_receipt_by_id(receipt_id, received_receipt)
+            .store_receipt(received_receipt.clone())
             .await
             .map_err(|err| Error::AdapterError {
                 source_error: anyhow::Error::new(err),

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -1,8 +1,6 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use alloy_primitives::Address;
 use alloy_sol_types::Eip712Domain;
 use futures::Future;
@@ -14,7 +12,7 @@ use crate::{
         rav_storage_adapter::{RAVRead, RAVStore},
         receipt_storage_adapter::{ReceiptDelete, ReceiptRead, ReceiptStore},
     },
-    checks::ReceiptCheck,
+    checks::Checks,
     receipt_aggregate_voucher::ReceiptAggregateVoucher,
     tap_receipt::{
         CategorizedReceiptsWithState, Failed, ReceiptAuditor, ReceiptWithId, ReceiptWithState,
@@ -28,10 +26,8 @@ pub struct Manager<E> {
     executor: E,
 
     /// Checks that must be completed for each receipt before being confirmed or denied for rav request
-    checks: Arc<[ReceiptCheck]>,
+    checks: Checks,
 
-    // /// Checks that must be completed for each receipt before being confirmed or denied for rav request
-    // finalize_checks: Arc<[ReceiptCheck]>,
     /// Struct responsible for doing checks for receipt. Ownership stays with manager allowing manager
     /// to update configuration ( like minimum timestamp ).
     receipt_auditor: ReceiptAuditor<E>,
@@ -48,7 +44,7 @@ where
     pub fn new(
         domain_separator: Eip712Domain,
         executor: E,
-        initial_checks: impl Into<Arc<[ReceiptCheck]>>,
+        initial_checks: impl Into<Checks>,
         // finalize_checks: impl Into<Arc<[ReceiptCheck]>>,
     ) -> Self {
         let receipt_auditor = ReceiptAuditor::new(domain_separator, executor.clone());

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -1,9 +1,7 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy_primitives::Address;
 use alloy_sol_types::Eip712Domain;
-use futures::Future;
 
 use super::{RAVRequest, SignedRAV, SignedReceipt};
 use crate::{
@@ -59,7 +57,7 @@ where
 
 impl<E> Manager<E>
 where
-    E: RAVStore,
+    E: RAVStore + EscrowAdapter,
 {
     /// Verify `signed_rav` matches all values on `expected_rav`, and that `signed_rav` has a valid signer.
     ///
@@ -67,19 +65,13 @@ where
     ///
     /// Returns [`Error::AdapterError`] if there are any errors while storing RAV
     ///
-    pub async fn verify_and_store_rav<F, Fut, Err>(
+    pub async fn verify_and_store_rav(
         &self,
         expected_rav: ReceiptAggregateVoucher,
         signed_rav: SignedRAV,
-        verify_signer: F,
-    ) -> std::result::Result<(), Error>
-    where
-        F: FnOnce(Address) -> Fut,
-        Fut: Future<Output = Result<bool, Err>>,
-        Err: std::fmt::Display,
-    {
+    ) -> std::result::Result<(), Error> {
         self.receipt_auditor
-            .check_rav_signature(&signed_rav, verify_signer)
+            .check_rav_signature(&signed_rav)
             .await?;
 
         if signed_rav.message != expected_rav {

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -10,7 +10,7 @@ use crate::{
     adapters::{
         escrow_adapter::EscrowAdapter,
         rav_storage_adapter::{RAVRead, RAVStore},
-        receipt_storage_adapter::{ReceiptRead, ReceiptStore},
+        receipt_storage_adapter::{ReceiptDelete, ReceiptRead, ReceiptStore},
     },
     checks::ReceiptCheck,
     receipt_aggregate_voucher::ReceiptAggregateVoucher,
@@ -242,7 +242,7 @@ where
 
 impl<E> Manager<E>
 where
-    E: ReceiptStore + RAVRead,
+    E: ReceiptDelete + RAVRead,
 {
     /// Removes obsolete receipts from storage. Obsolete receipts are receipts that are older than the last RAV, and
     /// therefore already aggregated into the RAV.

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -39,18 +39,12 @@ where
     /// will complete all `required_checks` before being accepted or declined from RAV.
     /// `starting_min_timestamp` will be used as min timestamp until the first RAV request is created.
     ///
-    pub fn new(
-        domain_separator: Eip712Domain,
-        executor: E,
-        initial_checks: impl Into<Checks>,
-        // finalize_checks: impl Into<Arc<[ReceiptCheck]>>,
-    ) -> Self {
+    pub fn new(domain_separator: Eip712Domain, executor: E, checks: impl Into<Checks>) -> Self {
         let receipt_auditor = ReceiptAuditor::new(domain_separator, executor.clone());
         Self {
             executor,
             receipt_auditor,
-            checks: initial_checks.into(),
-            // finalize_checks: finalize_checks.into(),
+            checks: checks.into(),
         }
     }
 }

--- a/tap_core/src/tap_manager/manager.rs
+++ b/tap_core/src/tap_manager/manager.rs
@@ -67,7 +67,7 @@ where
     ///
     /// Returns [`Error::AdapterError`] if there are any errors while storing RAV
     ///
-    pub async fn verify_and_store_rav<F, Fut>(
+    pub async fn verify_and_store_rav<F, Fut, Err>(
         &self,
         expected_rav: ReceiptAggregateVoucher,
         signed_rav: SignedRAV,
@@ -75,7 +75,8 @@ where
     ) -> std::result::Result<(), Error>
     where
         F: FnOnce(Address) -> Fut,
-        Fut: Future<Output = Result<bool, Error>>,
+        Fut: Future<Output = Result<bool, Err>>,
+        Err: std::fmt::Display,
     {
         self.receipt_auditor
             .check_rav_signature(&signed_rav, verify_signer)

--- a/tap_core/src/tap_manager/rav_request.rs
+++ b/tap_core/src/tap_manager/rav_request.rs
@@ -9,8 +9,7 @@ use crate::{
     tap_receipt::{Failed, ReceiptWithState},
 };
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(bound(deserialize = "'de: 'static"))]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RAVRequest {
     pub valid_receipts: Vec<SignedReceipt>,
     pub previous_rav: Option<SignedRAV>,

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -175,7 +175,6 @@ async fn manager_create_rav_request_all_valid_receipts(
             .is_ok());
     }
     let rav_request_result = manager.create_rav_request(0, None).await;
-    println!("{:?}", rav_request_result);
     assert!(rav_request_result.is_ok());
 
     let rav_request = rav_request_result.unwrap();

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -17,7 +17,7 @@ use crate::{
         executor_mock::{EscrowStorage, ExecutorMock, QueryAppraisals},
         receipt_storage_adapter::ReceiptRead,
     },
-    checks::{mock::get_full_list_of_checks, ReceiptCheck, TimestampCheck},
+    checks::{mock::get_full_list_of_checks, Checks, TimestampCheck},
     eip_712_signed_message::EIP712SignedMessage,
     get_current_timestamp_u64_ns, tap_eip712_domain,
     tap_receipt::Receipt,
@@ -65,7 +65,7 @@ struct ExecutorFixture {
     executor: ExecutorMock,
     escrow_storage: EscrowStorage,
     query_appraisals: QueryAppraisals,
-    checks: Vec<ReceiptCheck>,
+    checks: Checks,
 }
 
 #[fixture]
@@ -93,6 +93,7 @@ fn executor_mock(
         query_appraisals.clone(),
     );
     checks.push(timestamp_check);
+    let checks = Checks::new(checks);
 
     ExecutorFixture {
         executor,

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -192,7 +192,7 @@ async fn manager_create_rav_request_all_valid_receipts(
         .verify_and_store_rav(
             rav_request.expected_rav,
             signed_rav,
-            |address: Address| async move { Ok(keys.1 == address) }
+            |address: Address| async move { Ok::<bool, String>(keys.1 == address) }
         )
         .await
         .is_ok());
@@ -263,7 +263,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts(
         .verify_and_store_rav(
             rav_request.expected_rav,
             signed_rav,
-            |address: Address| async move { Ok(keys.1 == address) }
+            |address: Address| async move { Ok::<bool, String>(keys.1 == address) }
         )
         .await
         .is_ok());
@@ -313,7 +313,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts(
         .verify_and_store_rav(
             rav_request.expected_rav,
             signed_rav,
-            |address: Address| async move { Ok(keys.1 == address) }
+            |address: Address| async move { Ok::<bool, String>(keys.1 == address) }
         )
         .await
         .is_ok());
@@ -394,7 +394,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
         .verify_and_store_rav(
             rav_request_1.expected_rav,
             signed_rav_1,
-            |address: Address| async move { Ok(keys.1 == address) }
+            |address: Address| async move { Ok::<bool, String>(keys.1 == address) }
         )
         .await
         .is_ok());
@@ -459,7 +459,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
         .verify_and_store_rav(
             rav_request_2.expected_rav,
             signed_rav_2,
-            |address: Address| async move { Ok(keys.1 == address) }
+            |address: Address| async move { Ok::<bool, String>(keys.1 == address) }
         )
         .await
         .is_ok());

--- a/tap_core/src/tap_manager/test/manager_test.rs
+++ b/tap_core/src/tap_manager/test/manager_test.rs
@@ -73,6 +73,7 @@ fn executor_mock(
     domain_separator: Eip712Domain,
     allocation_ids: Vec<Address>,
     sender_ids: Vec<Address>,
+    keys: (LocalWallet, Address),
 ) -> ExecutorFixture {
     let escrow_storage = Arc::new(RwLock::new(HashMap::new()));
     let rav_storage = Arc::new(RwLock::new(None));
@@ -84,7 +85,8 @@ fn executor_mock(
         receipt_storage.clone(),
         escrow_storage.clone(),
         timestamp_check.clone(),
-    );
+    )
+    .with_sender_address(keys.1);
 
     let mut checks = get_full_list_of_checks(
         domain_separator,
@@ -189,11 +191,7 @@ async fn manager_create_rav_request_all_valid_receipts(
         EIP712SignedMessage::new(&domain_separator, rav_request.expected_rav.clone(), &keys.0)
             .unwrap();
     assert!(manager
-        .verify_and_store_rav(
-            rav_request.expected_rav,
-            signed_rav,
-            |address: Address| async move { Ok::<bool, String>(keys.1 == address) }
-        )
+        .verify_and_store_rav(rav_request.expected_rav, signed_rav)
         .await
         .is_ok());
 }
@@ -260,11 +258,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts(
         EIP712SignedMessage::new(&domain_separator, rav_request.expected_rav.clone(), &keys.0)
             .unwrap();
     assert!(manager
-        .verify_and_store_rav(
-            rav_request.expected_rav,
-            signed_rav,
-            |address: Address| async move { Ok::<bool, String>(keys.1 == address) }
-        )
+        .verify_and_store_rav(rav_request.expected_rav, signed_rav)
         .await
         .is_ok());
 
@@ -310,11 +304,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts(
         EIP712SignedMessage::new(&domain_separator, rav_request.expected_rav.clone(), &keys.0)
             .unwrap();
     assert!(manager
-        .verify_and_store_rav(
-            rav_request.expected_rav,
-            signed_rav,
-            |address: Address| async move { Ok::<bool, String>(keys.1 == address) }
-        )
+        .verify_and_store_rav(rav_request.expected_rav, signed_rav)
         .await
         .is_ok());
 }
@@ -391,11 +381,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
     )
     .unwrap();
     assert!(manager
-        .verify_and_store_rav(
-            rav_request_1.expected_rav,
-            signed_rav_1,
-            |address: Address| async move { Ok::<bool, String>(keys.1 == address) }
-        )
+        .verify_and_store_rav(rav_request_1.expected_rav, signed_rav_1)
         .await
         .is_ok());
 
@@ -456,11 +442,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
     )
     .unwrap();
     assert!(manager
-        .verify_and_store_rav(
-            rav_request_2.expected_rav,
-            signed_rav_2,
-            |address: Address| async move { Ok::<bool, String>(keys.1 == address) }
-        )
+        .verify_and_store_rav(rav_request_2.expected_rav, signed_rav_2)
         .await
         .is_ok());
 }

--- a/tap_core/src/tap_receipt/mod.rs
+++ b/tap_core/src/tap_receipt/mod.rs
@@ -33,8 +33,8 @@ pub enum ReceiptError {
     NonUniqueReceipt,
     #[error("Attempt to collect escrow failed")]
     SubtractEscrowFailed,
-    #[error("Issue encountered while performing check: {source_error_message}")]
-    CheckFailedToComplete { source_error_message: String },
+    #[error("Issue encountered while performing check: {0}")]
+    CheckFailedToComplete(String),
 }
 
 pub type ReceiptResult<T> = Result<T, ReceiptError>;

--- a/tap_core/src/tap_receipt/mod.rs
+++ b/tap_core/src/tap_receipt/mod.rs
@@ -4,7 +4,6 @@
 mod receipt;
 mod receipt_auditor;
 mod received_receipt;
-use std::collections::HashMap;
 
 use alloy_primitives::Address;
 pub use receipt::Receipt;
@@ -16,8 +15,6 @@ pub use received_receipt::{
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-
-use crate::checks::CheckingChecks;
 
 #[derive(Error, Debug, Clone, Serialize, Deserialize)]
 pub enum ReceiptError {
@@ -41,4 +38,3 @@ pub enum ReceiptError {
 }
 
 pub type ReceiptResult<T> = Result<T, ReceiptError>;
-pub type ReceiptCheckResults = HashMap<&'static str, CheckingChecks>;

--- a/tap_core/src/tap_receipt/receipt_auditor.rs
+++ b/tap_core/src/tap_receipt/receipt_auditor.rs
@@ -1,9 +1,7 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy_primitives::Address;
 use alloy_sol_types::Eip712Domain;
-use futures::Future;
 
 use crate::{
     adapters::escrow_adapter::EscrowAdapter,
@@ -24,29 +22,6 @@ impl<E> ReceiptAuditor<E> {
         Self {
             domain_separator,
             executor,
-        }
-    }
-
-    pub async fn check_rav_signature<F, Fut, Err>(
-        &self,
-        signed_rav: &SignedRAV,
-        verify_signer: F,
-    ) -> Result<(), Error>
-    where
-        F: FnOnce(Address) -> Fut,
-        Fut: Future<Output = Result<bool, Err>>,
-        Err: std::fmt::Display,
-    {
-        let recovered_address = signed_rav.recover_signer(&self.domain_separator)?;
-        if verify_signer(recovered_address)
-            .await
-            .map_err(|e| Error::FailedToVerifySigner(e.to_string()))?
-        {
-            Ok(())
-        } else {
-            Err(Error::InvalidRecoveredSigner {
-                address: recovered_address,
-            })
         }
     }
 }
@@ -76,5 +51,21 @@ where
         }
 
         Ok(())
+    }
+
+    pub async fn check_rav_signature(&self, signed_rav: &SignedRAV) -> Result<(), Error> {
+        let recovered_address = signed_rav.recover_signer(&self.domain_separator)?;
+        if self
+            .executor
+            .verify_signer(recovered_address)
+            .await
+            .map_err(|e| Error::FailedToVerifySigner(e.to_string()))?
+        {
+            Ok(())
+        } else {
+            Err(Error::InvalidRecoveredSigner {
+                address: recovered_address,
+            })
+        }
     }
 }

--- a/tap_core/src/tap_receipt/received_receipt.rs
+++ b/tap_core/src/tap_receipt/received_receipt.rs
@@ -208,9 +208,7 @@ impl ReceiptWithState<Checking> {
             check
                 .check(self)
                 .await
-                .map_err(|e| ReceiptError::CheckFailedToComplete {
-                    source_error_message: e.to_string(),
-                })?;
+                .map_err(|e| ReceiptError::CheckFailedToComplete(e.to_string()))?;
         }
         Ok(())
     }

--- a/tap_core/src/tap_receipt/received_receipt.rs
+++ b/tap_core/src/tap_receipt/received_receipt.rs
@@ -66,7 +66,8 @@ impl ReceiptState for AwaitingReserve {}
 impl ReceiptState for Reserved {}
 impl ReceiptState for Failed {}
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound(deserialize = "'de: 'static"))]
 pub enum ReceivedReceipt {
     AwaitingReserve(ReceiptWithState<AwaitingReserve>),
     Checking(ReceiptWithState<Checking>),

--- a/tap_core/src/tap_receipt/received_receipt/received_receipt_unit_test.rs
+++ b/tap_core/src/tap_receipt/received_receipt/received_receipt_unit_test.rs
@@ -70,6 +70,7 @@ fn executor_mock(
     domain_separator: Eip712Domain,
     allocation_ids: Vec<Address>,
     sender_ids: Vec<Address>,
+    keys: (LocalWallet, Address),
 ) -> ExecutorFixture {
     let escrow_storage = Arc::new(RwLock::new(HashMap::new()));
     let rav_storage = Arc::new(RwLock::new(None));
@@ -82,7 +83,8 @@ fn executor_mock(
         receipt_storage.clone(),
         escrow_storage.clone(),
         timestamp_check.clone(),
-    );
+    )
+    .with_sender_address(keys.1);
     let mut checks = get_full_list_of_checks(
         domain_separator,
         sender_ids.iter().cloned().collect(),

--- a/tap_integration_tests/tests/indexer_mock/mod.rs
+++ b/tap_integration_tests/tests/indexer_mock/mod.rs
@@ -211,7 +211,7 @@ where
         .verify_and_store_rav(
             rav_request.expected_rav,
             remote_rav_result.data,
-            |address| async move { Ok(address == expected_sender_id) },
+            |address| async move { Ok::<bool, String>(address == expected_sender_id) },
         )
         .await?;
 

--- a/tap_integration_tests/tests/indexer_mock/mod.rs
+++ b/tap_integration_tests/tests/indexer_mock/mod.rs
@@ -33,7 +33,6 @@ pub trait Rpc {
     #[method(name = "request")]
     async fn request(
         &self,
-        request_id: u64,        // Unique identifier for the request
         receipt: SignedReceipt, // Signed receipt associated with the request
     ) -> Result<(), jsonrpsee::types::ErrorObjectOwned>; // The result of the request, a JSON-RPC error if it fails
 }
@@ -90,7 +89,6 @@ where
 {
     async fn request(
         &self,
-        _request_id: u64,
         receipt: SignedReceipt,
     ) -> Result<(), jsonrpsee::types::ErrorObjectOwned> {
         let verify_result = match self.manager.verify_and_store_receipt(receipt).await {

--- a/tap_integration_tests/tests/indexer_mock/mod.rs
+++ b/tap_integration_tests/tests/indexer_mock/mod.rs
@@ -23,7 +23,7 @@ use tap_core::{
         rav_storage_adapter::{RAVRead, RAVStore},
         receipt_storage_adapter::{ReceiptRead, ReceiptStore},
     },
-    checks::ReceiptCheck,
+    checks::Checks,
     tap_manager::{Manager, SignedRAV, SignedReceipt},
 };
 /// Rpc trait represents a JSON-RPC server that has a single async method `request`.
@@ -64,7 +64,7 @@ where
     pub fn new(
         domain_separator: Eip712Domain,
         executor: E,
-        required_checks: Vec<ReceiptCheck>,
+        required_checks: Checks,
         threshold: u64,
         sender_id: Address,
         aggregate_server_address: String,
@@ -142,11 +142,11 @@ pub async fn run_server<E>(
     port: u16,                            // Port on which the server will listen
     domain_separator: Eip712Domain,       // EIP712 domain separator
     executor: E,                          // Executor instance
-    required_checks: Vec<ReceiptCheck>, // Vector of required checks to be performed on each request
-    threshold: u64,                     // The count at which a RAV request will be triggered
-    aggregate_server_address: String,   // Address of the aggregator server
+    required_checks: Checks, // Vector of required checks to be performed on each request
+    threshold: u64,          // The count at which a RAV request will be triggered
+    aggregate_server_address: String, // Address of the aggregator server
     aggregate_server_api_version: String, // API version of the aggregator server
-    sender_id: Address,                 // The sender address
+    sender_id: Address,      // The sender address
 ) -> Result<(ServerHandle, std::net::SocketAddr)>
 where
     E: ReceiptStore

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -187,13 +187,12 @@ fn executor(
         escrow_storage.clone(),
         timestamp_check.clone(),
     );
-    let mut checks = get_full_list_of_checks(
+    let checks = get_full_list_of_checks(
         domain_separator,
         sender_ids.iter().cloned().collect(),
         Arc::new(RwLock::new(allocation_ids.iter().cloned().collect())),
         query_appraisals,
     );
-    checks.push(timestamp_check);
 
     let checks = Checks::new(checks);
 

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -26,7 +26,7 @@ use tap_aggregator::{jsonrpsee_helpers, server as agg_server};
 use tap_core::{
     adapters::executor_mock::{ExecutorMock, QueryAppraisals},
     checks::{mock::get_full_list_of_checks, ReceiptCheck, TimestampCheck},
-    eip_712_signed_message::EIP712SignedMessage,
+    eip_712_signed_message::{EIP712SignedMessage, MessageId},
     tap_eip712_domain,
     tap_manager::SignedRAV,
     tap_receipt::Receipt,
@@ -159,7 +159,8 @@ fn query_appraisals(query_price: &[u128]) -> QueryAppraisals {
         query_price
             .iter()
             .enumerate()
-            .map(|(i, p)| (i as u64, *p))
+            // TODO update this
+            .map(|(i, p)| (MessageId([i as u8; 32]), *p))
             .collect(),
     ))
 }
@@ -190,7 +191,6 @@ fn executor(
         domain_separator,
         sender_ids.iter().cloned().collect(),
         Arc::new(RwLock::new(allocation_ids.iter().cloned().collect())),
-        receipt_storage,
         query_appraisals,
     );
     checks.push(timestamp_check);
@@ -376,7 +376,6 @@ async fn single_indexer_test_server(
         executor,
         sender_id,
         available_escrow,
-        checks.clone(),
         checks,
         receipt_threshold_1,
         sender_aggregator_addr,
@@ -433,7 +432,6 @@ async fn two_indexers_test_servers(
         executor_1,
         sender_id,
         available_escrow,
-        checks_1.clone(),
         checks_1,
         receipt_threshold_1,
         sender_aggregator_addr,
@@ -445,7 +443,6 @@ async fn two_indexers_test_servers(
         executor_2,
         sender_id,
         available_escrow,
-        checks_2.clone(),
         checks_2,
         receipt_threshold_1,
         sender_aggregator_addr,
@@ -491,7 +488,6 @@ async fn single_indexer_wrong_sender_test_server(
         executor,
         sender_id,
         available_escrow,
-        checks.clone(),
         checks,
         receipt_threshold_1,
         sender_aggregator_addr,
@@ -858,7 +854,6 @@ async fn start_indexer_server(
     mut executor: ExecutorMock,
     sender_id: Address,
     available_escrow: u128,
-    initial_checks: Vec<ReceiptCheck>,
     required_checks: Vec<ReceiptCheck>,
     receipt_threshold: u64,
     agg_server_addr: SocketAddr,
@@ -875,7 +870,6 @@ async fn start_indexer_server(
         http_port,
         domain_separator,
         executor,
-        initial_checks,
         required_checks,
         receipt_threshold,
         aggregate_server_address,

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -25,7 +25,7 @@ use rstest::*;
 use tap_aggregator::{jsonrpsee_helpers, server as agg_server};
 use tap_core::{
     adapters::executor_mock::{ExecutorMock, QueryAppraisals},
-    checks::{mock::get_full_list_of_checks, ReceiptCheck, TimestampCheck},
+    checks::{mock::get_full_list_of_checks, Checks, TimestampCheck},
     eip_712_signed_message::{EIP712SignedMessage, MessageId},
     tap_eip712_domain,
     tap_manager::SignedRAV,
@@ -167,7 +167,7 @@ fn query_appraisals(query_price: &[u128]) -> QueryAppraisals {
 
 struct ExecutorFixture {
     executor: ExecutorMock,
-    checks: Vec<ReceiptCheck>,
+    checks: Checks,
 }
 
 #[fixture]
@@ -194,6 +194,8 @@ fn executor(
         query_appraisals,
     );
     checks.push(timestamp_check);
+
+    let checks = Checks::new(checks);
 
     ExecutorFixture { executor, checks }
 }
@@ -854,7 +856,7 @@ async fn start_indexer_server(
     mut executor: ExecutorMock,
     sender_id: Address,
     available_escrow: u128,
-    required_checks: Vec<ReceiptCheck>,
+    required_checks: Checks,
     receipt_threshold: u64,
     agg_server_addr: SocketAddr,
 ) -> Result<(ServerHandle, SocketAddr)> {

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -871,12 +871,11 @@ async fn start_indexer_server(
     let (server_handle, socket_addr) = indexer_mock::run_server(
         http_port,
         domain_separator,
-        executor,
+        executor.with_sender_address(sender_id),
         required_checks,
         receipt_threshold,
         aggregate_server_address,
         aggregate_server_api_version(),
-        sender_id,
     )
     .await?;
 


### PR DESCRIPTION
This PR aims to lower the requisites to match what we use on tap-agent and indexer-service.

Some key points:
- Remove Serde from unneeded places like ReceivedReceipts. (also remove typetag, because we don't need to store state of checks)
- Remove stateful checking, now all the checks are done on verify
- Split ReceiptStore into: `ReceiptStore` and `ReceiptDelete`
- Remove query_id
- Add a `unique_hash()` for signed messages
- Remove `update_receipt_by_id` method because it's not needed anymore
- Split Check trait into: `Check` and `CheckBatch`
- Create a `Checks` type that is way more memory efficient to move things around.
- Create a `verify_signer` method for EscrowAdapter