### PR TITLE
chore(deps): update alloy-rs core types monorepo to 0.7.0

### DIFF
--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -28,8 +28,8 @@ prometheus = "0.13.3"
 axum = "0.6.18"
 futures-util = "0.3.28"
 lazy_static = "1.4.0"
-alloy-sol-types = { version = "0.6.0", features = ["eip712-serde"] }
-alloy-primitives = { version = "0.6.0", features = ["serde"] }
+alloy-sol-types = { version = "0.7.0", features = ["eip712-serde"] }
+alloy-primitives = { version = "0.7.0", features = ["serde"] }
 ethereum-types = "0.14.1"
 ruint = "1.10.1"
 

--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -19,8 +19,8 @@ ethers-core = "2.0.0"
 ethers-contract = "2.0.0"
 ethers-contract-derive = "2.0.0"
 anyhow = "1"
-alloy-sol-types = { version = "0.6.0", features = ["eip712-serde"] }
-alloy-primitives = { version = "0.6.0", features = ["serde"] }
+alloy-sol-types = { version = "0.7.0", features = ["eip712-serde"] }
+alloy-primitives = { version = "0.7.0", features = ["serde"] }
 
 strum = "0.24.1"
 strum_macros = "0.24.3"

--- a/tap_integration_tests/Cargo.toml
+++ b/tap_integration_tests/Cargo.toml
@@ -20,8 +20,8 @@ futures = "0.3.28"
 anyhow = "1.0.71"
 tokio = "1.28.2"
 prometheus = "0.13.3"
-alloy-sol-types = { version = "0.6.0", features = ["eip712-serde"] }
-alloy-primitives = { version = "0.6.0", features = ["serde"] }
+alloy-sol-types = { version = "0.7.0", features = ["eip712-serde"] }
+alloy-primitives = { version = "0.7.0", features = ["serde"] }
 
 [[test]]
 name = "integration_tests"


### PR DESCRIPTION
Recently, a new "major" version of the alloy-rs crates has been released. 

As this version is incompatible with the previous one in "semver terms", this PR updates the version to the latest one.