### PR TITLE
feat(tap-core): implement serialize for receipt with state

### DIFF
--- a/tap_core/src/receipt/received_receipt.rs
+++ b/tap_core/src/receipt/received_receipt.rs
@@ -14,6 +14,7 @@
 //! their progress through various checks and stages of inclusion in RAV requests and received RAVs.
 
 use alloy_sol_types::Eip712Domain;
+use serde::{Deserialize, Serialize};
 
 use super::{Receipt, ReceiptError, ReceiptResult, SignedReceipt};
 use crate::receipt::state::{AwaitingReserve, Checking, Failed, ReceiptState, Reserved};
@@ -37,7 +38,7 @@ pub type ResultReceipt<S> = std::result::Result<ReceiptWithState<S>, ReceiptWith
 /// awaiting escrow reservation.
 /// - The [ `Reserved` ] state is used to represent a receipt that has
 /// successfully reserved escrow.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReceiptWithState<S>
 where
     S: ReceiptState,

--- a/tap_core/src/receipt/state.rs
+++ b/tap_core/src/receipt/state.rs
@@ -8,13 +8,14 @@
 //! The `ReceiptState` trait represents the different states a receipt can be in.
 
 use crate::receipt::ReceiptError;
+use serde::{Deserialize, Serialize};
 
 /// Checking state represents a receipt that is currently being checked.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Checking;
 
 /// Failed state represents a receipt that has failed a check or validation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Failed {
     /// A list of checks to be completed for the receipt, along with their
     /// current result
@@ -23,11 +24,11 @@ pub struct Failed {
 
 /// AwaitingReserve state represents a receipt that has passed all checks
 /// and is awaiting escrow reservation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AwaitingReserve;
 
 /// Reserved state represents a receipt that has successfully reserved escrow.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Reserved;
 
 /// Trait for the different states a receipt can be in.


### PR DESCRIPTION
The `Serialize` trait is necessary to send over JSON-RPC the list of valid receipts here:

https://github.com/graphprotocol/indexer-rs/blob/7f544b283f88451b5c1173f880140134da06a392/tap-agent/src/agent/sender_allocation.rs#L521-L530

Without this, the latest changes in the `main` branch cannot be used in the `indexer-rs` repository, and as a consequence, preventing the _alloy_ crates upgrade.