### PR TITLE
obtain invalid receipts

### DIFF
--- a/tap_core/src/manager/tap_manager.rs
+++ b/tap_core/src/manager/tap_manager.rs
@@ -219,9 +219,7 @@ where
             .collect_receipts(timestamp_buffer_ns, min_timestamp_ns, receipts_limit)
             .await?;
 
-        Ok(
-            invalid_receipts,
-        )
+        Ok(invalid_receipts)
     }
 
     fn generate_expected_rav(

--- a/tap_core/src/manager/tap_manager.rs
+++ b/tap_core/src/manager/tap_manager.rs
@@ -204,24 +204,6 @@ where
         })
     }
 
-    pub async fn obtain_invalid_receipts(
-        &self,
-        timestamp_buffer_ns: u64,
-        receipts_limit: Option<u64>,
-    ) -> Result<Vec<ReceiptWithState<Failed>>, Error> {
-        let previous_rav = self.get_previous_rav().await?;
-        let min_timestamp_ns = previous_rav
-            .as_ref()
-            .map(|rav| rav.message.timestampNs + 1)
-            .unwrap_or(0);
-
-        let (_, invalid_receipts) = self
-            .collect_receipts(timestamp_buffer_ns, min_timestamp_ns, receipts_limit)
-            .await?;
-
-        Ok(invalid_receipts)
-    }
-
     fn generate_expected_rav(
         receipts: &[ReceiptWithState<Reserved>],
         previous_rav: Option<SignedRAV>,

--- a/tap_core/src/manager/tap_manager.rs
+++ b/tap_core/src/manager/tap_manager.rs
@@ -204,6 +204,26 @@ where
         })
     }
 
+    pub async fn obtain_invalid_receipts(
+        &self,
+        timestamp_buffer_ns: u64,
+        receipts_limit: Option<u64>,
+    ) -> Result<Vec<ReceiptWithState<Failed>>, Error> {
+        let previous_rav = self.get_previous_rav().await?;
+        let min_timestamp_ns = previous_rav
+            .as_ref()
+            .map(|rav| rav.message.timestampNs + 1)
+            .unwrap_or(0);
+
+        let (_, invalid_receipts) = self
+            .collect_receipts(timestamp_buffer_ns, min_timestamp_ns, receipts_limit)
+            .await?;
+
+        Ok(
+            invalid_receipts,
+        )
+    }
+
     fn generate_expected_rav(
         receipts: &[ReceiptWithState<Reserved>],
         previous_rav: Option<SignedRAV>,

--- a/tap_core/src/manager/tap_manager.rs
+++ b/tap_core/src/manager/tap_manager.rs
@@ -194,7 +194,7 @@ where
             .collect_receipts(timestamp_buffer_ns, min_timestamp_ns, receipts_limit)
             .await?;
 
-        let expected_rav = Self::generate_expected_rav(&valid_receipts, previous_rav.clone())?;
+        let expected_rav = Self::generate_expected_rav(&valid_receipts, previous_rav.clone());
 
         Ok(RAVRequest {
             valid_receipts,

--- a/tap_core/src/rav/request.rs
+++ b/tap_core/src/rav/request.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::receipt::state::Reserved;
+use crate::Error;
 use crate::{
     rav::{ReceiptAggregateVoucher, SignedRAV},
     receipt::{state::Failed, ReceiptWithState},
@@ -17,5 +18,5 @@ pub struct RAVRequest {
     /// List of failed receipt used to log invalid receipts
     pub invalid_receipts: Vec<ReceiptWithState<Failed>>,
     /// Expected RAV to be created
-    pub expected_rav: ReceiptAggregateVoucher,
+    pub expected_rav: Result<ReceiptAggregateVoucher, Error>,
 }

--- a/tap_core/tests/manager_test.rs
+++ b/tap_core/tests/manager_test.rs
@@ -198,11 +198,13 @@ async fn manager_create_rav_request_all_valid_receipts(
     // no failing
     assert_eq!(rav_request.invalid_receipts.len(), 0);
 
+    let expected_rav = rav_request.expected_rav.unwrap();
+
     let signed_rav =
-        EIP712SignedMessage::new(&domain_separator, rav_request.expected_rav.clone(), &signer)
+        EIP712SignedMessage::new(&domain_separator, expected_rav.clone(), &signer)
             .unwrap();
     assert!(manager
-        .verify_and_store_rav(rav_request.expected_rav, signed_rav)
+        .verify_and_store_rav(expected_rav, signed_rav)
         .await
         .is_ok());
 }
@@ -292,19 +294,21 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts(
     );
     // no receipts failing
     assert_eq!(rav_request.invalid_receipts.len(), 0);
+
+    let expected_rav = rav_request.expected_rav.unwrap();
     // accumulated value is correct
     assert_eq!(
-        rav_request.expected_rav.valueAggregate,
+        expected_rav.valueAggregate,
         expected_accumulated_value
     );
     // no previous rav
     assert!(rav_request.previous_rav.is_none());
 
     let signed_rav =
-        EIP712SignedMessage::new(&domain_separator, rav_request.expected_rav.clone(), &signer)
+        EIP712SignedMessage::new(&domain_separator, expected_rav.clone(), &signer)
             .unwrap();
     assert!(manager
-        .verify_and_store_rav(rav_request.expected_rav, signed_rav)
+        .verify_and_store_rav(expected_rav, signed_rav)
         .await
         .is_ok());
 
@@ -338,19 +342,21 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts(
     );
     // no receipts failing
     assert_eq!(rav_request.invalid_receipts.len(), 0);
+
+    let expected_rav = rav_request.expected_rav.unwrap();
     // accumulated value is correct
     assert_eq!(
-        rav_request.expected_rav.valueAggregate,
+        expected_rav.valueAggregate,
         expected_accumulated_value
     );
     // Verify there is a previous rav
     assert!(rav_request.previous_rav.is_some());
 
     let signed_rav =
-        EIP712SignedMessage::new(&domain_separator, rav_request.expected_rav.clone(), &signer)
+        EIP712SignedMessage::new(&domain_separator, expected_rav.clone(), &signer)
             .unwrap();
     assert!(manager
-        .verify_and_store_rav(rav_request.expected_rav, signed_rav)
+        .verify_and_store_rav(expected_rav, signed_rav)
         .await
         .is_ok());
 }
@@ -415,9 +421,11 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
     );
     // no receipts failing
     assert_eq!(rav_request_1.invalid_receipts.len(), 0);
+
+    let expected_rav_1 = rav_request_1.expected_rav.unwrap();
     // accumulated value is correct
     assert_eq!(
-        rav_request_1.expected_rav.valueAggregate,
+        expected_rav_1.valueAggregate,
         expected_accumulated_value
     );
     // no previous rav
@@ -425,12 +433,12 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
 
     let signed_rav_1 = EIP712SignedMessage::new(
         &domain_separator,
-        rav_request_1.expected_rav.clone(),
+        expected_rav_1.clone(),
         &signer,
     )
     .unwrap();
     assert!(manager
-        .verify_and_store_rav(rav_request_1.expected_rav, signed_rav_1)
+        .verify_and_store_rav(expected_rav_1, signed_rav_1)
         .await
         .is_ok());
 
@@ -475,9 +483,11 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
     );
     // no receipts failing
     assert_eq!(rav_request_2.invalid_receipts.len(), 0);
+
+    let expected_rav_2 = rav_request_2.expected_rav.unwrap();
     // accumulated value is correct
     assert_eq!(
-        rav_request_2.expected_rav.valueAggregate,
+        expected_rav_2.valueAggregate,
         expected_accumulated_value
     );
     // Verify there is a previous rav
@@ -485,12 +495,12 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
 
     let signed_rav_2 = EIP712SignedMessage::new(
         &domain_separator,
-        rav_request_2.expected_rav.clone(),
+        expected_rav_2.clone(),
         &signer,
     )
     .unwrap();
     assert!(manager
-        .verify_and_store_rav(rav_request_2.expected_rav, signed_rav_2)
+        .verify_and_store_rav(expected_rav_2, signed_rav_2)
         .await
         .is_ok());
 }
@@ -535,10 +545,11 @@ async fn manager_create_rav_and_ignore_invalid_receipts(
     }
 
     let rav_request = manager.create_rav_request(0, None).await.unwrap();
+    let expected_rav = rav_request.expected_rav.unwrap();
 
     assert_eq!(rav_request.valid_receipts.len(), 1);
     // All receipts but one being invalid
     assert_eq!(rav_request.invalid_receipts.len(), 9);
     //Rav Value corresponds only to value of one receipt
-    assert_eq!(rav_request.expected_rav.valueAggregate, 20);
+    assert_eq!(expected_rav.valueAggregate, 20);
 }

--- a/tap_core/tests/manager_test.rs
+++ b/tap_core/tests/manager_test.rs
@@ -201,8 +201,7 @@ async fn manager_create_rav_request_all_valid_receipts(
     let expected_rav = rav_request.expected_rav.unwrap();
 
     let signed_rav =
-        EIP712SignedMessage::new(&domain_separator, expected_rav.clone(), &signer)
-            .unwrap();
+        EIP712SignedMessage::new(&domain_separator, expected_rav.clone(), &signer).unwrap();
     assert!(manager
         .verify_and_store_rav(expected_rav, signed_rav)
         .await
@@ -297,16 +296,12 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts(
 
     let expected_rav = rav_request.expected_rav.unwrap();
     // accumulated value is correct
-    assert_eq!(
-        expected_rav.valueAggregate,
-        expected_accumulated_value
-    );
+    assert_eq!(expected_rav.valueAggregate, expected_accumulated_value);
     // no previous rav
     assert!(rav_request.previous_rav.is_none());
 
     let signed_rav =
-        EIP712SignedMessage::new(&domain_separator, expected_rav.clone(), &signer)
-            .unwrap();
+        EIP712SignedMessage::new(&domain_separator, expected_rav.clone(), &signer).unwrap();
     assert!(manager
         .verify_and_store_rav(expected_rav, signed_rav)
         .await
@@ -345,16 +340,12 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts(
 
     let expected_rav = rav_request.expected_rav.unwrap();
     // accumulated value is correct
-    assert_eq!(
-        expected_rav.valueAggregate,
-        expected_accumulated_value
-    );
+    assert_eq!(expected_rav.valueAggregate, expected_accumulated_value);
     // Verify there is a previous rav
     assert!(rav_request.previous_rav.is_some());
 
     let signed_rav =
-        EIP712SignedMessage::new(&domain_separator, expected_rav.clone(), &signer)
-            .unwrap();
+        EIP712SignedMessage::new(&domain_separator, expected_rav.clone(), &signer).unwrap();
     assert!(manager
         .verify_and_store_rav(expected_rav, signed_rav)
         .await
@@ -424,19 +415,12 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
 
     let expected_rav_1 = rav_request_1.expected_rav.unwrap();
     // accumulated value is correct
-    assert_eq!(
-        expected_rav_1.valueAggregate,
-        expected_accumulated_value
-    );
+    assert_eq!(expected_rav_1.valueAggregate, expected_accumulated_value);
     // no previous rav
     assert!(rav_request_1.previous_rav.is_none());
 
-    let signed_rav_1 = EIP712SignedMessage::new(
-        &domain_separator,
-        expected_rav_1.clone(),
-        &signer,
-    )
-    .unwrap();
+    let signed_rav_1 =
+        EIP712SignedMessage::new(&domain_separator, expected_rav_1.clone(), &signer).unwrap();
     assert!(manager
         .verify_and_store_rav(expected_rav_1, signed_rav_1)
         .await
@@ -486,19 +470,12 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
 
     let expected_rav_2 = rav_request_2.expected_rav.unwrap();
     // accumulated value is correct
-    assert_eq!(
-        expected_rav_2.valueAggregate,
-        expected_accumulated_value
-    );
+    assert_eq!(expected_rav_2.valueAggregate, expected_accumulated_value);
     // Verify there is a previous rav
     assert!(rav_request_2.previous_rav.is_some());
 
-    let signed_rav_2 = EIP712SignedMessage::new(
-        &domain_separator,
-        expected_rav_2.clone(),
-        &signer,
-    )
-    .unwrap();
+    let signed_rav_2 =
+        EIP712SignedMessage::new(&domain_separator, expected_rav_2.clone(), &signer).unwrap();
     assert!(manager
         .verify_and_store_rav(expected_rav_2, signed_rav_2)
         .await

--- a/tap_integration_tests/tests/indexer_mock.rs
+++ b/tap_integration_tests/tests/indexer_mock.rs
@@ -201,7 +201,7 @@ where
         .request("aggregate_receipts", params)
         .await?;
     manager
-        .verify_and_store_rav(rav_request.expected_rav, remote_rav_result.data)
+        .verify_and_store_rav(rav_request.expected_rav?, remote_rav_result.data)
         .await?;
 
     // For these tests, we expect every receipt to be valid, i.e. there should be no invalid receipts, nor any missing receipts (less than the expected threshold).


### PR DESCRIPTION
This goes in hand with [#214](https://github.com/graphprotocol/indexer-rs/issues/214) in indexer-rs
Currently we have an issue were if all receipts are invalid when calling [create_rav_request](https://github.com/semiotic-ai/timeline-aggregation-protocol/blob/main/tap_core/src/manager/tap_manager.rs#L182) > [generate_expect_rav](https://github.com/semiotic-ai/timeline-aggregation-protocol/blob/main/tap_core/src/manager/tap_manager.rs#L207) it turns back an **[error](https://github.com/semiotic-ai/timeline-aggregation-protocol/blob/main/tap_core/src/manager/tap_manager.rs#L212)** and cant go on with moving the **invalid** receipts to the `failed_receipts` table
~Considered modifying that function but its good to have that error to understand what is going on. So im adding another function `obtain_invalid_receipts` so after it errors out to obtain only the invalid ones and move them.~
Made `exepected_rav` to be a result and handle it afterwards