### PR TITLE
chore(deps): update rust crate alloy to v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 repository = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
 
 [workspace.dependencies]
-alloy = { version = "0.5.4", features = ["full"] }
+alloy = { version = "0.6", features = ["full"] }
 serde = { version = "1.0.163", features = ["derive"] }
 rstest = "0.22.0"
 anyhow = { version = "1.0.89" }

--- a/tap_core/src/signed_message.rs
+++ b/tap_core/src/signed_message.rs
@@ -27,8 +27,8 @@
 
 use alloy::{
     dyn_abi::Eip712Domain,
-    primitives::Address,
-    signers::{local::PrivateKeySigner, Signature, SignerSync},
+    primitives::{Address, PrimitiveSignature as Signature},
+    signers::{local::PrivateKeySigner, SignerSync},
     sol_types::SolStruct,
 };
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
This pull request includes updates to dependencies and some code restructuring to improve compatibility and maintainability. The most important changes include upgrading the `alloy` dependency and restructuring imports in the `tap_core/src/signed_message.rs` file.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L12-R12): Upgraded `alloy` dependency from version `0.5.4` to `0.6`.

New version compatibility changes:
 
* [`tap_core/src/signed_message.rs`](diffhunk://#diff-703ea6a00960e5a0ceac7afceb445cd614bdc6e7788a615aadf0d56ac2b61607L30-R31): Restructured imports to use `PrimitiveSignature` from `alloy::primitives` and adjusted other related imports.