### PR TITLE
chore(deps): update rust crate alloy to v0.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     container:
-      image: rust:1.79-bookworm
+      image: rust:1.82-bookworm
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -23,7 +23,7 @@ jobs:
     name: cargo clippy
     runs-on: ubuntu-latest
     container:
-      image: rust:1.79-bookworm
+      image: rust:1.82-bookworm
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -47,7 +47,7 @@ jobs:
       pull-requests: write
       actions: read
     container:
-      image: rust:1.79-bookworm
+      image: rust:1.82-bookworm
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -72,7 +72,7 @@ jobs:
     name: cargo test docs
     runs-on: ubuntu-latest
     container:
-      image: rust:1.79-bookworm
+      image: rust:1.82-bookworm
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82-bookworm
+      image: rust:1.83-bookworm
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -23,7 +23,7 @@ jobs:
     name: cargo clippy
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82-bookworm
+      image: rust:1.83-bookworm
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -47,7 +47,7 @@ jobs:
       pull-requests: write
       actions: read
     container:
-      image: rust:1.82-bookworm
+      image: rust:1.83-bookworm
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -72,7 +72,7 @@ jobs:
     name: cargo test docs
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82-bookworm
+      image: rust:1.83-bookworm
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 repository = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
 
 [workspace.dependencies]
-alloy = { version = "0.6", features = ["full"] }
+alloy = { version = "0.7", features = ["full"] }
 serde = { version = "1.0.163", features = ["derive"] }
 rstest = "0.22.0"
 anyhow = { version = "1.0.89" }

--- a/Dockerfile.tap_aggregator
+++ b/Dockerfile.tap_aggregator
@@ -1,4 +1,4 @@
-FROM rust:1.79-bookworm as build
+FROM rust:1.82-bookworm as build
 
 WORKDIR /root
 COPY . .

--- a/Dockerfile.tap_aggregator
+++ b/Dockerfile.tap_aggregator
@@ -1,4 +1,4 @@
-FROM rust:1.82-bookworm as build
+FROM rust:1.83-bookworm as build
 
 WORKDIR /root
 COPY . .

--- a/tap_core/benches/timeline_aggretion_protocol_benchmark.rs
+++ b/tap_core/benches/timeline_aggretion_protocol_benchmark.rs
@@ -72,7 +72,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .collect::<Vec<_>>();
 
         rav_group.bench_function(
-            &format!("Create RAV w/ 2^{} receipt's", log_number_of_receipts),
+            format!("Create RAV w/ 2^{} receipt's", log_number_of_receipts),
             |b| {
                 b.iter(|| {
                     ReceiptAggregateVoucher::aggregate_receipts(
@@ -92,7 +92,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .unwrap();
 
         rav_group.bench_function(
-            &format!("Validate RAV w/ 2^{} receipt's", log_number_of_receipts),
+            format!("Validate RAV w/ 2^{} receipt's", log_number_of_receipts),
             |b| b.iter(|| black_box(&signed_rav).verify(&domain_seperator, black_box(address))),
         );
     }


### PR DESCRIPTION
This pull request includes a version update to the `alloy` dependency in the `Cargo.toml` file. The version has been incremented from `0.6` to `0.7`.

Dependency update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L12-R12): Updated `alloy` dependency from version `0.6` to `0.7`.