### PR TITLE
chore(deps): update rust crate alloy to v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 repository = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
 
 [workspace.dependencies]
-alloy = { version = "0.7", features = ["full"] }
+alloy = { version = "0.8", features = ["full"] }
 serde = { version = "1.0.163", features = ["derive"] }
 rstest = "0.22.0"
 anyhow = { version = "1.0.89" }


### PR DESCRIPTION
This pull request includes an update to the `Cargo.toml` file to upgrade the version of the `alloy` dependency.

Dependency version update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L12-R12): Updated the `alloy` dependency from version `0.7` to `0.8`.