### PR TITLE
feat: add tap v2

### DIFF
--- a/tap_core/src/error.rs
+++ b/tap_core/src/error.rs
@@ -47,8 +47,18 @@ pub enum Error {
     NoValidReceiptsForRAVRequest,
 
     /// Error when the previous RAV allocation id does not match the allocation id from the new receipt
-    #[error("Previous RAV allocation id ({prev_id}) doesn't match the allocation id from the new receipt ({new_id}).")]
-    RavAllocationIdMismatch { prev_id: String, new_id: String },
+    #[error(
+        "Previous RAV payer ({prev_id}) doesn't match the payer from the new receipt ({new_id})."
+    )]
+    RavPayerMismatch { prev_id: String, new_id: String },
+
+    /// Error when the previous RAV data service does not match the data service from the new receipt
+    #[error("Previous RAV data_service ({prev_id}) doesn't match the data_service from the new receipt ({new_id}).")]
+    RavDataServiceMismatch { prev_id: String, new_id: String },
+
+    /// Error when the previous RAV service provider does not match the service provider from the new receipt
+    #[error("Previous RAV service_provider ({prev_id}) doesn't match the service_provider from the new receipt ({new_id}).")]
+    RavServiceProviderMismatch { prev_id: String, new_id: String },
 
     /// Error when all receipts do not have the same allocation id
     ///

--- a/tap_core/src/manager/context/memory.rs
+++ b/tap_core/src/manager/context/memory.rs
@@ -276,13 +276,13 @@ pub mod checks {
     pub fn get_full_list_of_checks(
         domain_separator: Eip712Domain,
         valid_signers: HashSet<Address>,
-        allocation_ids: Arc<RwLock<HashSet<Address>>>,
+        payers: Arc<RwLock<HashSet<Address>>>,
         _query_appraisals: Arc<RwLock<HashMap<MessageId, u128>>>,
     ) -> Vec<ReceiptCheck> {
         vec![
             // Arc::new(UniqueCheck ),
             // Arc::new(ValueCheck { query_appraisals }),
-            Arc::new(AllocationIdCheck { allocation_ids }),
+            Arc::new(PayerCheck { payers }),
             Arc::new(SignatureCheck {
                 domain_separator,
                 valid_signers,
@@ -290,16 +290,16 @@ pub mod checks {
         ]
     }
 
-    struct AllocationIdCheck {
-        allocation_ids: Arc<RwLock<HashSet<Address>>>,
+    struct PayerCheck {
+        payers: Arc<RwLock<HashSet<Address>>>,
     }
 
     #[async_trait::async_trait]
-    impl Check for AllocationIdCheck {
+    impl Check for PayerCheck {
         async fn check(&self, _: &Context, receipt: &ReceiptWithState<Checking>) -> CheckResult {
-            let received_allocation_id = receipt.signed_receipt().message.allocation_id;
+            let received_allocation_id = receipt.signed_receipt().message.payer;
             if self
-                .allocation_ids
+                .payers
                 .read()
                 .unwrap()
                 .contains(&received_allocation_id)

--- a/tap_core/src/manager/mod.rs
+++ b/tap_core/src/manager/mod.rs
@@ -66,7 +66,7 @@
 //! # use tap_core::signed_message::EIP712SignedMessage;
 //! # let domain_separator = Eip712Domain::default();
 //! # let wallet = PrivateKeySigner::random();
-//! # let message = Receipt::new(Address::from([0x11u8; 20]), 100).unwrap();
+//! # let message = Receipt::new(Address::ZERO, Address::ZERO, Address::ZERO, 100).unwrap();
 //!
 //! let receipt = EIP712SignedMessage::new(&domain_separator, message, &wallet).unwrap();
 //!

--- a/tap_core/src/manager/tap_manager.rs
+++ b/tap_core/src/manager/tap_manager.rs
@@ -216,13 +216,17 @@ where
         if receipts.is_empty() {
             return Err(Error::NoValidReceiptsForRAVRequest);
         }
-        let allocation_id = receipts[0].signed_receipt().message.allocation_id;
+        let payer = receipts[0].signed_receipt().message.payer;
+        let service_provider = receipts[0].signed_receipt().message.service_provider;
+        let data_service = receipts[0].signed_receipt().message.data_service;
         let receipts = receipts
             .iter()
             .map(|rx_receipt| rx_receipt.signed_receipt().clone())
             .collect::<Vec<_>>();
         ReceiptAggregateVoucher::aggregate_receipts(
-            allocation_id,
+            payer,
+            service_provider,
+            data_service,
             receipts.as_slice(),
             previous_rav,
         )

--- a/tap_core/src/receipt/checks.rs
+++ b/tap_core/src/receipt/checks.rs
@@ -200,11 +200,11 @@ impl CheckBatch for UniqueCheck {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
     use std::time::Duration;
     use std::time::SystemTime;
 
     use alloy::dyn_abi::Eip712Domain;
+    use alloy::primitives::address;
     use alloy::primitives::Address;
     use alloy::signers::local::PrivateKeySigner;
     use alloy::sol_types::eip712_domain;
@@ -235,8 +235,9 @@ mod tests {
         let receipt = EIP712SignedMessage::new(
             &eip712_domain_separator,
             Receipt {
-                allocation_id: Address::from_str("0xabababababababababababababababababababab")
-                    .unwrap(),
+                payer: address!("abababababababababababababababababababab"),
+                data_service: address!("abababababababababababababababababababab"),
+                service_provider: address!("abababababababababababababababababababab"),
                 nonce,
                 timestamp_ns,
                 value,

--- a/tap_core/src/signed_message.rs
+++ b/tap_core/src/signed_message.rs
@@ -16,7 +16,7 @@
 //! };
 //! # let wallet = PrivateKeySigner::random();
 //! # let wallet_address = wallet.address();
-//! # let message = Receipt::new(Address::from([0x11u8; 20]), 100).unwrap();
+//! # let message = Receipt::new(Address::ZERO, Address::ZERO, Address::ZERO, 100).unwrap();
 //!
 //! let signed_message = EIP712SignedMessage::new(&domain_separator, message, &wallet).unwrap();
 //! let signer = signed_message.recover_signer(&domain_separator).unwrap();

--- a/tap_core/tests/rav_test.rs
+++ b/tap_core/tests/rav_test.rs
@@ -1,11 +1,13 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::sync::RwLock;
-use std::{str::FromStr, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 use alloy::dyn_abi::Eip712Domain;
+use alloy::primitives::address;
 #[allow(deprecated)]
 use alloy::primitives::{Address, PrimitiveSignature, Signature};
 use alloy::signers::local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner};
@@ -42,7 +44,9 @@ fn context() -> InMemoryContext {
 
 #[rstest]
 fn check_for_rav_serialization(domain_separator: Eip712Domain) {
-    let allocation_id = Address::from_str("0xabababababababababababababababababababab").unwrap();
+    let payer = address!("abababababababababababababababababababab");
+    let data_service = address!("abababababababababababababababababababab");
+    let service_provider = address!("abababababababababababababababababababab");
     let wallet = MnemonicBuilder::<English>::default()
         .phrase("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
         .build()
@@ -53,7 +57,9 @@ fn check_for_rav_serialization(domain_separator: Eip712Domain) {
             EIP712SignedMessage::new(
                 &domain_separator,
                 Receipt {
-                    allocation_id,
+                    payer,
+                    data_service,
+                    service_provider,
                     value,
                     nonce: value as u64,
                     timestamp_ns: value as u64,
@@ -66,7 +72,14 @@ fn check_for_rav_serialization(domain_separator: Eip712Domain) {
 
     let signed_rav = EIP712SignedMessage::new(
         &domain_separator,
-        ReceiptAggregateVoucher::aggregate_receipts(allocation_id, &receipts, None).unwrap(),
+        ReceiptAggregateVoucher::aggregate_receipts(
+            payer,
+            data_service,
+            service_provider,
+            &receipts,
+            None,
+        )
+        .unwrap(),
         &wallet,
     )
     .unwrap();
@@ -90,7 +103,9 @@ fn check_for_rav_serialization(domain_separator: Eip712Domain) {
 async fn rav_storage_adapter_test(domain_separator: Eip712Domain, context: InMemoryContext) {
     let wallet = PrivateKeySigner::random();
 
-    let allocation_id = Address::from_str("0xabababababababababababababababababababab").unwrap();
+    let payer = address!("abababababababababababababababababababab");
+    let data_service = address!("abababababababababababababababababababab");
+    let service_provider = address!("abababababababababababababababababababab");
 
     // Create receipts
     let mut receipts = Vec::new();
@@ -98,7 +113,7 @@ async fn rav_storage_adapter_test(domain_separator: Eip712Domain, context: InMem
         receipts.push(
             EIP712SignedMessage::new(
                 &domain_separator,
-                Receipt::new(allocation_id, value).unwrap(),
+                Receipt::new(payer, data_service, service_provider, value).unwrap(),
                 &wallet,
             )
             .unwrap(),
@@ -107,7 +122,14 @@ async fn rav_storage_adapter_test(domain_separator: Eip712Domain, context: InMem
 
     let signed_rav = EIP712SignedMessage::new(
         &domain_separator,
-        ReceiptAggregateVoucher::aggregate_receipts(allocation_id, &receipts, None).unwrap(),
+        ReceiptAggregateVoucher::aggregate_receipts(
+            payer,
+            data_service,
+            service_provider,
+            &receipts,
+            None,
+        )
+        .unwrap(),
         &wallet,
     )
     .unwrap();
@@ -126,7 +148,7 @@ async fn rav_storage_adapter_test(domain_separator: Eip712Domain, context: InMem
         receipts.push(
             EIP712SignedMessage::new(
                 &domain_separator,
-                Receipt::new(allocation_id, value).unwrap(),
+                Receipt::new(payer, data_service, service_provider, value).unwrap(),
                 &wallet,
             )
             .unwrap(),
@@ -135,7 +157,14 @@ async fn rav_storage_adapter_test(domain_separator: Eip712Domain, context: InMem
 
     let signed_rav = EIP712SignedMessage::new(
         &domain_separator,
-        ReceiptAggregateVoucher::aggregate_receipts(allocation_id, &receipts, None).unwrap(),
+        ReceiptAggregateVoucher::aggregate_receipts(
+            payer,
+            data_service,
+            service_provider,
+            &receipts,
+            None,
+        )
+        .unwrap(),
         &wallet,
     )
     .unwrap();

--- a/tap_core/tests/receipt_test.rs
+++ b/tap_core/tests/receipt_test.rs
@@ -1,12 +1,11 @@
 use alloy::dyn_abi::Eip712Domain;
-use alloy::primitives::Address;
+use alloy::primitives::{address, Address};
 use alloy::signers::local::PrivateKeySigner;
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use tap_core::manager::context::memory::InMemoryContext;
 use tap_core::receipt::{state::Checking, ReceiptWithState};
@@ -43,14 +42,16 @@ fn context() -> InMemoryContext {
 async fn receipt_adapter_test(domain_separator: Eip712Domain, mut context: InMemoryContext) {
     let wallet = PrivateKeySigner::random();
 
-    let allocation_id = Address::from_str("0xabababababababababababababababababababab").unwrap();
+    let payer = address!("abababababababababababababababababababab");
+    let data_service = address!("abababababababababababababababababababab");
+    let service_provider = address!("abababababababababababababababababababab");
 
     // Create receipts
     let value = 100u128;
     let received_receipt = ReceiptWithState::new(
         EIP712SignedMessage::new(
             &domain_separator,
-            Receipt::new(allocation_id, value).unwrap(),
+            Receipt::new(payer, data_service, service_provider, value).unwrap(),
             &wallet,
         )
         .unwrap(),
@@ -82,7 +83,9 @@ async fn receipt_adapter_test(domain_separator: Eip712Domain, mut context: InMem
 async fn multi_receipt_adapter_test(domain_separator: Eip712Domain, mut context: InMemoryContext) {
     let wallet = PrivateKeySigner::random();
 
-    let allocation_id = Address::from_str("0xabababababababababababababababababababab").unwrap();
+    let payer = address!("abababababababababababababababababababab");
+    let data_service = address!("abababababababababababababababababababab");
+    let service_provider = address!("abababababababababababababababababababab");
 
     // Create receipts
     let mut received_receipts = Vec::new();
@@ -90,7 +93,7 @@ async fn multi_receipt_adapter_test(domain_separator: Eip712Domain, mut context:
         received_receipts.push(ReceiptWithState::new(
             EIP712SignedMessage::new(
                 &domain_separator,
-                Receipt::new(allocation_id, value).unwrap(),
+                Receipt::new(payer, data_service, service_provider, value).unwrap(),
                 &wallet,
             )
             .unwrap(),
@@ -168,7 +171,9 @@ fn safe_truncate_receipts_test(
             EIP712SignedMessage::new(
                 &domain_separator,
                 Receipt {
-                    allocation_id: Address::ZERO,
+                    payer: Address::ZERO,
+                    data_service: Address::ZERO,
+                    service_provider: Address::ZERO,
                     timestamp_ns: *timestamp,
                     nonce: 0,
                     value: 0,

--- a/tap_core/tests/received_receipt_test.rs
+++ b/tap_core/tests/received_receipt_test.rs
@@ -7,7 +7,11 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
+use alloy::{
+    dyn_abi::Eip712Domain,
+    primitives::{address, Address},
+    signers::local::PrivateKeySigner,
+};
 use rstest::*;
 use tap_core::{
     manager::context::memory::{
@@ -34,6 +38,21 @@ fn allocation_ids() -> Vec<Address> {
         Address::from_str("0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef").unwrap(),
         Address::from_str("0x1234567890abcdef1234567890abcdef12345678").unwrap(),
     ]
+}
+
+#[fixture]
+fn payer() -> Address {
+    address!("abababababababababababababababababababab")
+}
+
+#[fixture]
+fn data_service() -> Address {
+    address!("deaddeaddeaddeaddeaddeaddeaddeaddeaddead")
+}
+
+#[fixture]
+fn service_provider() -> Address {
+    address!("beefbeefbeefbeefbeefbeefbeefbeefbeefbeef")
 }
 
 #[fixture]
@@ -104,7 +123,9 @@ fn context(
 #[tokio::test]
 async fn partial_then_full_check_valid_receipt(
     domain_separator: Eip712Domain,
-    allocation_ids: Vec<Address>,
+    payer: Address,
+    data_service: Address,
+    service_provider: Address,
     context: ContextFixture,
 ) {
     let ContextFixture {
@@ -118,7 +139,7 @@ async fn partial_then_full_check_valid_receipt(
     let query_value = 20u128;
     let signed_receipt = EIP712SignedMessage::new(
         &domain_separator,
-        Receipt::new(allocation_ids[0], query_value).unwrap(),
+        Receipt::new(payer, data_service, service_provider, query_value).unwrap(),
         &signer,
     )
     .unwrap();
@@ -147,7 +168,9 @@ async fn partial_then_full_check_valid_receipt(
 #[rstest]
 #[tokio::test]
 async fn partial_then_finalize_valid_receipt(
-    allocation_ids: Vec<Address>,
+    payer: Address,
+    data_service: Address,
+    service_provider: Address,
     domain_separator: Eip712Domain,
     context: ContextFixture,
 ) {
@@ -163,7 +186,7 @@ async fn partial_then_finalize_valid_receipt(
     let query_value = 20u128;
     let signed_receipt = EIP712SignedMessage::new(
         &domain_separator,
-        Receipt::new(allocation_ids[0], query_value).unwrap(),
+        Receipt::new(payer, data_service, service_provider, query_value).unwrap(),
         &signer,
     )
     .unwrap();
@@ -198,7 +221,9 @@ async fn partial_then_finalize_valid_receipt(
 #[rstest]
 #[tokio::test]
 async fn standard_lifetime_valid_receipt(
-    allocation_ids: Vec<Address>,
+    payer: Address,
+    data_service: Address,
+    service_provider: Address,
     domain_separator: Eip712Domain,
     context: ContextFixture,
 ) {
@@ -214,7 +239,7 @@ async fn standard_lifetime_valid_receipt(
     let query_value = 20u128;
     let signed_receipt = EIP712SignedMessage::new(
         &domain_separator,
-        Receipt::new(allocation_ids[0], query_value).unwrap(),
+        Receipt::new(payer, data_service, service_provider, query_value).unwrap(),
         &signer,
     )
     .unwrap();

--- a/tap_core/tests/snapshots/rav_test__check_for_rav_serialization-2.snap
+++ b/tap_core/tests/snapshots/rav_test__check_for_rav_serialization-2.snap
@@ -5,13 +5,16 @@ snapshot_kind: text
 ---
 {
   "message": {
-    "allocationId": "0xabababababababababababababababababababab",
+    "payer": "0xabababababababababababababababababababab",
+    "dataService": "0xabababababababababababababababababababab",
+    "serviceProvider": "0xabababababababababababababababababababab",
     "timestampNs": 59,
-    "valueAggregate": 545
+    "valueAggregate": 545,
+    "metadata": "0x"
   },
   "signature": {
-    "r": "0x11d760201bac73d4e772d0999a1f9b5f6b8d8979d94ee29b7cb2659d23f2a551",
-    "s": "0x1036a994ff414de83f24601ab7cc22e0ece134d2199e0b675d94bd8cf7015226",
+    "r": "0xe1a54286f4c8d483c410eb1d6a3972593d81b3f6d89458d9c177b4cd0aaf7fa9",
+    "s": "0x1307ee4fee865c2fad8e6373ad5873a54f614ecb4d8f60ead3641e6c1b959405",
     "yParity": "0x0",
     "v": "0x0"
   }

--- a/tap_core/tests/snapshots/rav_test__check_for_rav_serialization.snap
+++ b/tap_core/tests/snapshots/rav_test__check_for_rav_serialization.snap
@@ -6,142 +6,162 @@ snapshot_kind: text
 [
   {
     "message": {
-      "allocation_id": "0xabababababababababababababababababababab",
+      "payer": "0xabababababababababababababababababababab",
+      "data_service": "0xabababababababababababababababababababab",
+      "service_provider": "0xabababababababababababababababababababab",
       "timestamp_ns": 50,
       "nonce": 50,
       "value": 50
     },
     "signature": {
-      "r": "0x5257bab234e33525cd999db4defc805c2d3b4e51cde3697f43e37ce39473720f",
-      "s": "0x6c3af14c3d400dfd047fd2da90eb9e8cee863e77cc52742ebcbf080b8d6ec2",
+      "r": "0x4ecb862a64112bcdac18567b9ecdea86bdaa23278363dd9ad7b0866460443cff",
+      "s": "0x55c351e35b610c372d988d9854701c4c539ca171f0daad0e2da391689cb9b739",
       "yParity": "0x1",
       "v": "0x1"
     }
   },
   {
     "message": {
-      "allocation_id": "0xabababababababababababababababababababab",
+      "payer": "0xabababababababababababababababababababab",
+      "data_service": "0xabababababababababababababababababababab",
+      "service_provider": "0xabababababababababababababababababababab",
       "timestamp_ns": 51,
       "nonce": 51,
       "value": 51
     },
     "signature": {
-      "r": "0x1596dd0d380ede7aa5dec5ed09ea7d1fa8e4bc8dfdb43a4e965bb4f16906e321",
-      "s": "0x788b69625a031fbd2e769928b63505387df16e7c51f19ff67c782bfec101a387",
+      "r": "0xb86b4f2a3952fe0a63b853571f9ba3a8949d60fd47aa77b4079507b2e0d183a9",
+      "s": "0x6f0692e52df1a2162080ef8f471032b2d456fd64f193f0be42e461ad9be69f44",
       "yParity": "0x0",
       "v": "0x0"
     }
   },
   {
     "message": {
-      "allocation_id": "0xabababababababababababababababababababab",
+      "payer": "0xabababababababababababababababababababab",
+      "data_service": "0xabababababababababababababababababababab",
+      "service_provider": "0xabababababababababababababababababababab",
       "timestamp_ns": 52,
       "nonce": 52,
       "value": 52
     },
     "signature": {
-      "r": "0xb3b8e2c1249fc14183024e28b14f7749ef852c898906c2442f380a26bf07a625",
-      "s": "0x6925e7dce01d539a658d552e43cfd92d9d204d6997604f8f613977251b964db3",
-      "yParity": "0x1",
-      "v": "0x1"
+      "r": "0xcc84e1950cf91c07596e9e8a7919a438f41598d2ad0b1d36bd4ca873387e3bf",
+      "s": "0x69ba08cbf960f893276193b2ceb285cd4597d681a841c9f09f36d56aee579edb",
+      "yParity": "0x0",
+      "v": "0x0"
     }
   },
   {
     "message": {
-      "allocation_id": "0xabababababababababababababababababababab",
+      "payer": "0xabababababababababababababababababababab",
+      "data_service": "0xabababababababababababababababababababab",
+      "service_provider": "0xabababababababababababababababababababab",
       "timestamp_ns": 53,
       "nonce": 53,
       "value": 53
     },
     "signature": {
-      "r": "0x3b4d08db319497c2cc0d515d25057e28ce44b194a23e84b9d35682f97027c7e3",
-      "s": "0x232e02eb4b52d302d620867a4c10829e5a307404ea1bcbbd2ee33e8422a18a16",
-      "yParity": "0x1",
-      "v": "0x1"
+      "r": "0x9ea79f4be4c140a264e2d1a203cd7dd93d1495b25093783bb7fb18a2c22d0fe5",
+      "s": "0x39040040de42a251eae1c0a71e08d775416351f05199be7807400dce1d498afd",
+      "yParity": "0x0",
+      "v": "0x0"
     }
   },
   {
     "message": {
-      "allocation_id": "0xabababababababababababababababababababab",
+      "payer": "0xabababababababababababababababababababab",
+      "data_service": "0xabababababababababababababababababababab",
+      "service_provider": "0xabababababababababababababababababababab",
       "timestamp_ns": 54,
       "nonce": 54,
       "value": 54
     },
     "signature": {
-      "r": "0x619d84f659ea3941cdb0656100b2ea8a3d2f5658dbd67f796ebfb8840156530b",
-      "s": "0x163b236f88207b89452255da8ce196997d8f2f0880081659c780f2093797f75e",
-      "yParity": "0x1",
-      "v": "0x1"
+      "r": "0x21f8af664178560f5aa274ea98ee145ce479d1295da4fed08c3d7102df8cc2af",
+      "s": "0x540418686c0f21d48786e46f773205d2b4ecaa5f0876cf6c8f4dff15d89d7510",
+      "yParity": "0x0",
+      "v": "0x0"
     }
   },
   {
     "message": {
-      "allocation_id": "0xabababababababababababababababababababab",
+      "payer": "0xabababababababababababababababababababab",
+      "data_service": "0xabababababababababababababababababababab",
+      "service_provider": "0xabababababababababababababababababababab",
       "timestamp_ns": 55,
       "nonce": 55,
       "value": 55
     },
     "signature": {
-      "r": "0x48e1e0e31eaf40eabbcbc3c6d125b7656c0796d51188f89d27194e22f2c5d6bb",
-      "s": "0xd26efc0ae8cc3646993a20b5aabac1125ecb149ad91d733c702ac9f03222b66",
+      "r": "0x522915411cc85754f513d582c1d6fc38fa348a48eac0b8fddb3293ba87e41437",
+      "s": "0xde39cb8b91574ec392bc07367aea8df7d1cf37f9d2489ff6e5b4ea8b5ee50f2",
       "yParity": "0x1",
       "v": "0x1"
     }
   },
   {
     "message": {
-      "allocation_id": "0xabababababababababababababababababababab",
+      "payer": "0xabababababababababababababababababababab",
+      "data_service": "0xabababababababababababababababababababab",
+      "service_provider": "0xabababababababababababababababababababab",
       "timestamp_ns": 56,
       "nonce": 56,
       "value": 56
     },
     "signature": {
-      "r": "0xc3adb8be5db130f563d3a18fc9e742fca84f69a903413e04dc567b9c3aca8626",
-      "s": "0x564dd73bdd33897c7a085e4eb1bc0ce002b1d65c6006781ab54cd670846fe358",
-      "yParity": "0x0",
-      "v": "0x0"
+      "r": "0x7b0199df25fc87969fcdf795e9cfd246e743d786a9208614b00d8af03730398",
+      "s": "0x772b54a7bc5da81d06534b8e524fa0e52019f76c826eead029c7903fcb19ea42",
+      "yParity": "0x1",
+      "v": "0x1"
     }
   },
   {
     "message": {
-      "allocation_id": "0xabababababababababababababababababababab",
+      "payer": "0xabababababababababababababababababababab",
+      "data_service": "0xabababababababababababababababababababab",
+      "service_provider": "0xabababababababababababababababababababab",
       "timestamp_ns": 57,
       "nonce": 57,
       "value": 57
     },
     "signature": {
-      "r": "0xa0fe51e1b7253daed14f99c9320d0a539ef18b6ead6552947e5c93dde6f40dea",
-      "s": "0x4277d66d3a8c9f67cddc8d96a71ef8437e47e34a5b5789d7843eb691c3b9864",
+      "r": "0x72d7802e0802e8391469a9711259e6a9983ebab673d2baf7eceadfef9c2afc77",
+      "s": "0x647e0ae9f3ef205d31955b3ac3e132296b57b1b218cb5f221678ca7ab7e0b875",
       "yParity": "0x0",
       "v": "0x0"
     }
   },
   {
     "message": {
-      "allocation_id": "0xabababababababababababababababababababab",
+      "payer": "0xabababababababababababababababababababab",
+      "data_service": "0xabababababababababababababababababababab",
+      "service_provider": "0xabababababababababababababababababababab",
       "timestamp_ns": 58,
       "nonce": 58,
       "value": 58
     },
     "signature": {
-      "r": "0x26f1657e4b8759867820be12c25e982e15ff9d70aa99fe1fd2587cbb644829de",
-      "s": "0x5cabbd965f93e544b07e5956c2831148dbf7960b4e2edadfa6ecbf1209dacda4",
+      "r": "0x98a01a0cad9ff3ab95157d03c6d253872935149f361fa3003b4776ea095b907e",
+      "s": "0x55034f5bdac601bd78a3091d82450e844a8ff1e554498fb0ef6b8c4ef9e61a6",
       "yParity": "0x0",
       "v": "0x0"
     }
   },
   {
     "message": {
-      "allocation_id": "0xabababababababababababababababababababab",
+      "payer": "0xabababababababababababababababababababab",
+      "data_service": "0xabababababababababababababababababababab",
+      "service_provider": "0xabababababababababababababababababababab",
       "timestamp_ns": 59,
       "nonce": 59,
       "value": 59
     },
     "signature": {
-      "r": "0x90ce08049b9ce9fa38077ebeed0e24558442d8ae001aeff6b9f4b06f4f553c69",
-      "s": "0x7a873491448ae696555f9d1314b4e78a7cc98a19a6b0c26aad562053dc26a202",
-      "yParity": "0x1",
-      "v": "0x1"
+      "r": "0x27ce1976e8a0645d04e31f95c14b038f75de27e8fb1e4604b1ac7723232228cb",
+      "s": "0x31652a9a504057ca9c22d577370538d38b3c8a74070e3a844172e280f6587946",
+      "yParity": "0x0",
+      "v": "0x0"
     }
   }
 ]

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -219,6 +219,8 @@ fn requests_1(
         num_batches,
         &keys_sender,
         allocation_ids[0],
+        allocation_ids[0],
+        allocation_ids[0],
         &domain_separator,
     )
 }
@@ -236,6 +238,8 @@ fn requests_2(
         query_price,
         num_batches,
         &keys_sender,
+        allocation_ids[1],
+        allocation_ids[1],
         allocation_ids[1],
         &domain_separator,
     )
@@ -256,6 +260,8 @@ fn repeated_timestamp_request(
         num_batches,
         &keys_sender,
         allocation_ids[0],
+        allocation_ids[0],
+        allocation_ids[0],
         &domain_separator,
     );
 
@@ -265,7 +271,9 @@ fn repeated_timestamp_request(
         .timestamp_ns;
     let target_receipt = &requests[receipt_threshold_1 as usize].message;
     let repeat_receipt = Receipt {
-        allocation_id: target_receipt.allocation_id,
+        payer: target_receipt.payer,
+        data_service: target_receipt.data_service,
+        service_provider: target_receipt.service_provider,
         timestamp_ns: repeat_timestamp,
         nonce: target_receipt.nonce,
         value: target_receipt.value,
@@ -292,6 +300,8 @@ fn repeated_timestamp_incremented_by_one_request(
         num_batches,
         &keys_sender,
         allocation_ids[0],
+        allocation_ids[0],
+        allocation_ids[0],
         &domain_separator,
     );
 
@@ -302,7 +312,9 @@ fn repeated_timestamp_incremented_by_one_request(
         + 1;
     let target_receipt = &requests[receipt_threshold_1 as usize].message;
     let repeat_receipt = Receipt {
-        allocation_id: target_receipt.allocation_id,
+        payer: target_receipt.payer,
+        data_service: target_receipt.data_service,
+        service_provider: target_receipt.service_provider,
         timestamp_ns: repeat_timestamp,
         nonce: target_receipt.nonce,
         value: target_receipt.value,
@@ -329,6 +341,8 @@ fn wrong_requests(
         query_price,
         num_batches,
         &wrong_keys_sender,
+        allocation_ids[0],
+        allocation_ids[0],
         allocation_ids[0],
         &domain_separator,
     )
@@ -773,7 +787,9 @@ fn generate_requests(
     query_price: &[u128],
     num_batches: u64,
     sender_key: &PrivateKeySigner,
-    allocation_id: Address,
+    payer: Address,
+    data_service: Address,
+    service_provider: Address,
     domain_separator: &Eip712Domain,
 ) -> Vec<EIP712SignedMessage<Receipt>> {
     let mut requests: Vec<EIP712SignedMessage<Receipt>> = Vec::new();
@@ -783,7 +799,7 @@ fn generate_requests(
             requests.push(
                 EIP712SignedMessage::new(
                     domain_separator,
-                    Receipt::new(allocation_id, *value).unwrap(),
+                    Receipt::new(payer, data_service, service_provider, *value).unwrap(),
                     sender_key,
                 )
                 .unwrap(),


### PR DESCRIPTION
- update receipt aggregate voucher to mimic the same as in https://github.com/graphprotocol/contracts/blob/horizon/packages/horizon/contracts/interfaces/ITAPCollector.sol
- update receipt struct to contain the same restrictions
- update all tests accordingly
- update tap-aggregator to aggregate receipts v2 into rav v2