### PR TITLE
perf: add rayon to verify signatures process

### DIFF
--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -39,10 +39,10 @@ tower = { version = "0.4", features = ["util", "steer"] }
 tonic = { version = "0.12.3", features = ["transport", "zstd"] }
 prost = "0.13.3"
 hyper = { version = "1", features = ["full"] }
+rayon = "1.10.0"
 
 [build-dependencies]
 tonic-build = "0.12.3"
-
 
 [dev-dependencies]
 jsonrpsee = { workspace = true, features = ["http-client", "jsonrpsee-core"] }


### PR DESCRIPTION
Adding rayon to signatures makes it ~4,5x faster


Without Rayon:
1k receipts: 2.4832964
10k receipts: 24.968279

With Rayon:
1k receipts: 0.541488
10k receipts: 5.4854965