### PR TITLE
refactor: format imports using cargo fmt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,15 @@ jobs:
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest
-    container:
-      image: rust:1.83-bookworm
     steps:
-      - uses: actions/checkout@v3
-      - run: |
-          rustup component add rustfmt
-          cargo fmt --all -- --check
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1
+        with:
+          # Imports formatting is an unstable feature, so we need to use nightly
+          toolchain: nightly
+          components: rustfmt
+          cache: false
+      - run: cargo +nightly fmt --all -- --check
 
   clippy:
     name: cargo clippy

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,7 @@
 edition = "2021"
+
+# Enable nightly features required for formatting imports
+unstable_features = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+reorder_modules = true

--- a/tap_aggregator/src/aggregator.rs
+++ b/tap_aggregator/src/aggregator.rs
@@ -137,9 +137,9 @@ mod tests {
 
     use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
     use rstest::*;
+    use tap_core::{receipt::Receipt, signed_message::EIP712SignedMessage, tap_eip712_domain};
 
     use crate::aggregator;
-    use tap_core::{receipt::Receipt, signed_message::EIP712SignedMessage, tap_eip712_domain};
 
     #[fixture]
     fn keys() -> (PrivateKeySigner, Address) {

--- a/tap_aggregator/src/main.rs
+++ b/tap_aggregator/src/main.rs
@@ -9,9 +9,8 @@ use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateK
 use anyhow::Result;
 use clap::Parser;
 use log::{debug, info};
-use tap_core::tap_eip712_domain;
-
 use tap_aggregator::{metrics, server};
+use tap_core::tap_eip712_domain;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/tap_aggregator/src/server.rs
+++ b/tap_aggregator/src/server.rs
@@ -388,20 +388,18 @@ fn create_json_rpc_service(
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 mod tests {
-    use std::collections::HashSet;
-    use std::str::FromStr;
+    use std::{collections::HashSet, str::FromStr};
 
     use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
     use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
-    use rand::prelude::*;
-    use rand::seq::SliceRandom;
+    use rand::{prelude::*, seq::SliceRandom};
     use rstest::*;
-
-    use crate::server;
     use tap_core::{
         rav::ReceiptAggregateVoucher, receipt::Receipt, signed_message::EIP712SignedMessage,
         tap_eip712_domain,
     };
+
+    use crate::server;
 
     #[derive(Clone)]
     struct Keys {

--- a/tap_aggregator/tests/aggregate_test.rs
+++ b/tap_aggregator/tests/aggregate_test.rs
@@ -4,7 +4,6 @@
 use std::{collections::HashSet, str::FromStr};
 
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
-
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use tap_aggregator::{
     grpc::{tap_aggregator_client::TapAggregatorClient, RavRequest},

--- a/tap_core/benches/timeline_aggretion_protocol_benchmark.rs
+++ b/tap_core/benches/timeline_aggretion_protocol_benchmark.rs
@@ -10,13 +10,11 @@
 
 use std::str::FromStr;
 
-use alloy::dyn_abi::Eip712Domain;
-use alloy::primitives::Address;
-use alloy::signers::local::PrivateKeySigner;
+use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use tap_core::tap_eip712_domain;
 use tap_core::{
     rav::ReceiptAggregateVoucher, receipt::Receipt, signed_message::EIP712SignedMessage,
+    tap_eip712_domain,
 };
 
 pub fn create_and_sign_receipt(

--- a/tap_core/src/error.rs
+++ b/tap_core/src/error.rs
@@ -4,10 +4,12 @@
 //! Module containing Error type and Result typedef
 //!
 
-use crate::{rav::ReceiptAggregateVoucher, receipt::ReceiptError};
-use alloy::primitives::{Address, SignatureError};
 use std::result::Result as StdResult;
+
+use alloy::primitives::{Address, SignatureError};
 use thiserror::Error as ThisError;
+
+use crate::{rav::ReceiptAggregateVoucher, receipt::ReceiptError};
 
 /// Error type for the TAP protocol
 #[derive(ThisError, Debug)]

--- a/tap_core/src/manager/context/memory.rs
+++ b/tap_core/src/manager/context/memory.rs
@@ -6,17 +6,21 @@
 //! This module provides an in-memory implementation of the TAP manager context.
 //! It is useful for testing and development purposes.
 
+use std::{
+    collections::HashMap,
+    ops::RangeBounds,
+    sync::{Arc, RwLock},
+};
+
+use alloy::primitives::Address;
+use async_trait::async_trait;
+
 use crate::{
     manager::adapters::*,
     rav::SignedRAV,
     receipt::{checks::StatefulTimestampCheck, state::Checking, ReceiptWithState},
     signed_message::MessageId,
 };
-use alloy::primitives::Address;
-use async_trait::async_trait;
-use std::ops::RangeBounds;
-use std::sync::RwLock;
-use std::{collections::HashMap, sync::Arc};
 
 pub type EscrowStorage = Arc<RwLock<HashMap<Address, u128>>>;
 pub type QueryAppraisals = Arc<RwLock<HashMap<MessageId, u128>>>;
@@ -259,6 +263,13 @@ impl EscrowHandler for InMemoryContext {
 }
 
 pub mod checks {
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::{Arc, RwLock},
+    };
+
+    use alloy::{dyn_abi::Eip712Domain, primitives::Address};
+
     use crate::{
         receipt::{
             checks::{Check, CheckError, CheckResult, ReceiptCheck},
@@ -266,11 +277,6 @@ pub mod checks {
             Context, ReceiptError, ReceiptWithState,
         },
         signed_message::MessageId,
-    };
-    use alloy::{dyn_abi::Eip712Domain, primitives::Address};
-    use std::{
-        collections::{HashMap, HashSet},
-        sync::{Arc, RwLock},
     };
 
     pub fn get_full_list_of_checks(

--- a/tap_core/src/rav.rs
+++ b/tap_core/src/rav.rs
@@ -41,12 +41,10 @@ mod request;
 
 use std::cmp;
 
-use alloy::primitives::Address;
-use alloy::sol;
+use alloy::{primitives::Address, sol};
 use serde::{Deserialize, Serialize};
 
-use crate::Error;
-use crate::{receipt::Receipt, signed_message::EIP712SignedMessage};
+use crate::{receipt::Receipt, signed_message::EIP712SignedMessage, Error};
 
 /// EIP712 signed message for ReceiptAggregateVoucher
 pub type SignedRAV = EIP712SignedMessage<ReceiptAggregateVoucher>;

--- a/tap_core/src/rav/request.rs
+++ b/tap_core/src/rav/request.rs
@@ -1,11 +1,13 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::receipt::state::Reserved;
-use crate::Error;
 use crate::{
     rav::{ReceiptAggregateVoucher, SignedRAV},
-    receipt::{state::Failed, ReceiptWithState},
+    receipt::{
+        state::{Failed, Reserved},
+        ReceiptWithState,
+    },
+    Error,
 };
 
 /// Request to `tap_aggregator` to aggregate receipts into a Signed RAV.

--- a/tap_core/src/receipt/checks.rs
+++ b/tap_core/src/receipt/checks.rs
@@ -29,17 +29,17 @@
 //! let my_check: ReceiptCheck = Arc::new(MyCheck);
 //! ```
 
-use crate::signed_message::{SignatureBytes, SignatureBytesExt};
-
-use super::{
-    state::{Checking, Failed},
-    Context, ReceiptError, ReceiptWithState,
-};
 use std::{
     collections::HashSet,
     ops::Deref,
     sync::{Arc, RwLock},
 };
+
+use super::{
+    state::{Checking, Failed},
+    Context, ReceiptError, ReceiptWithState,
+};
+use crate::signed_message::{SignatureBytes, SignatureBytesExt};
 
 /// ReceiptCheck is a type alias for an Arc of a struct that implements the `Check` trait.
 pub type ReceiptCheck = Arc<dyn Check + Sync + Send>;
@@ -200,19 +200,18 @@ impl CheckBatch for UniqueCheck {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-    use std::time::Duration;
-    use std::time::SystemTime;
+    use std::{
+        str::FromStr,
+        time::{Duration, SystemTime},
+    };
 
-    use alloy::dyn_abi::Eip712Domain;
-    use alloy::primitives::Address;
-    use alloy::signers::local::PrivateKeySigner;
-    use alloy::sol_types::eip712_domain;
-
-    use crate::receipt::Receipt;
-    use crate::signed_message::EIP712SignedMessage;
+    use alloy::{
+        dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+        sol_types::eip712_domain,
+    };
 
     use super::*;
+    use crate::{receipt::Receipt, signed_message::EIP712SignedMessage};
 
     fn create_signed_receipt_with_custom_value(value: u128) -> ReceiptWithState<Checking> {
         let wallet: PrivateKeySigner = PrivateKeySigner::random();

--- a/tap_core/src/receipt/receipt_sol.rs
+++ b/tap_core/src/receipt/receipt_sol.rs
@@ -43,10 +43,14 @@ impl Receipt {
 
 #[cfg(test)]
 mod receipt_unit_test {
-    use super::*;
+    use std::{
+        str::FromStr,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
     use rstest::*;
-    use std::str::FromStr;
-    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
 
     #[fixture]
     fn allocation_ids() -> Vec<Address> {

--- a/tap_core/src/receipt/received_receipt.rs
+++ b/tap_core/src/receipt/received_receipt.rs
@@ -15,11 +15,13 @@
 
 use alloy::dyn_abi::Eip712Domain;
 
-use super::checks::CheckError;
-use super::{Context, Receipt, ReceiptError, ReceiptResult, SignedReceipt};
-use crate::receipt::state::{AwaitingReserve, Checking, Failed, ReceiptState, Reserved};
+use super::{checks::CheckError, Context, Receipt, ReceiptError, ReceiptResult, SignedReceipt};
 use crate::{
-    manager::adapters::EscrowHandler, receipt::checks::ReceiptCheck,
+    manager::adapters::EscrowHandler,
+    receipt::{
+        checks::ReceiptCheck,
+        state::{AwaitingReserve, Checking, Failed, ReceiptState, Reserved},
+    },
     signed_message::EIP712SignedMessage,
 };
 

--- a/tap_core/tests/escrow_test.rs
+++ b/tap_core/tests/escrow_test.rs
@@ -8,7 +8,6 @@ use std::{
 
 use alloy::signers::local::PrivateKeySigner;
 use rstest::*;
-
 use tap_core::{
     manager::{adapters::EscrowHandler, context::memory::InMemoryContext},
     receipt::checks::StatefulTimestampCheck,

--- a/tap_core/tests/rav_test.rs
+++ b/tap_core/tests/rav_test.rs
@@ -1,19 +1,24 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::sync::RwLock;
-use std::{str::FromStr, sync::Arc};
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    sync::{Arc, RwLock},
+};
 
-use alloy::dyn_abi::Eip712Domain;
 #[allow(deprecated)]
 use alloy::primitives::{Address, PrimitiveSignature, Signature};
-use alloy::signers::local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner};
+use alloy::{
+    dyn_abi::Eip712Domain,
+    signers::local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner},
+};
 use rstest::*;
-
-use tap_core::manager::context::memory::InMemoryContext;
 use tap_core::{
-    manager::adapters::{RAVRead, RAVStore},
+    manager::{
+        adapters::{RAVRead, RAVStore},
+        context::memory::InMemoryContext,
+    },
     rav::ReceiptAggregateVoucher,
     receipt::{checks::StatefulTimestampCheck, Receipt},
     signed_message::EIP712SignedMessage,

--- a/tap_core/tests/receipt_test.rs
+++ b/tap_core/tests/receipt_test.rs
@@ -1,20 +1,19 @@
-use alloy::dyn_abi::Eip712Domain;
-use alloy::primitives::Address;
-use alloy::signers::local::PrivateKeySigner;
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    sync::{Arc, RwLock},
+};
+
+use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use rand::seq::SliceRandom;
 use rand::thread_rng;
-use std::collections::HashMap;
-use std::str::FromStr;
-use std::sync::{Arc, RwLock};
-use tap_core::manager::context::memory::InMemoryContext;
-use tap_core::receipt::{state::Checking, ReceiptWithState};
-
 use rstest::*;
-use tap_core::receipt::checks::StatefulTimestampCheck;
 use tap_core::{
-    manager::adapters::ReceiptStore, receipt::Receipt, signed_message::EIP712SignedMessage,
+    manager::{adapters::ReceiptStore, context::memory::InMemoryContext},
+    receipt::{checks::StatefulTimestampCheck, state::Checking, Receipt, ReceiptWithState},
+    signed_message::EIP712SignedMessage,
     tap_eip712_domain,
 };
 

--- a/tap_integration_tests/tests/indexer_mock.rs
+++ b/tap_integration_tests/tests/indexer_mock.rs
@@ -14,7 +14,6 @@ use jsonrpsee::{
     rpc_params,
     server::{ServerBuilder, ServerHandle},
 };
-
 use tap_aggregator::jsonrpsee_helpers;
 use tap_core::{
     manager::{

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -23,7 +23,6 @@ use jsonrpsee::{
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rstest::*;
-
 use tap_aggregator::{jsonrpsee_helpers, server as agg_server};
 use tap_core::{
     manager::context::memory::{checks::get_full_list_of_checks, *},


### PR DESCRIPTION
This pull request includes several changes aimed at improving code organization and formatting across multiple files, as well as updates to the GitHub Actions workflow. The most important changes include the reorganization of imports, enabling nightly features for Rust formatting, and updating the GitHub Actions workflow for formatting checks.

### Code organization and formatting:

* Reorganized imports to group them more logically and improve readability across multiple files (`tap_aggregator/src/aggregator.rs`, `tap_aggregator/src/main.rs`, `tap_aggregator/src/server.rs`, `tap_aggregator/tests/aggregate_test.rs`, `tap_core/benches/timeline_aggretion_protocol_benchmark.rs`, `tap_core/src/error.rs`, `tap_core/src/manager/context/memory.rs`, `tap_core/src/rav.rs`, `tap_core/src/rav/request.rs`, `tap_core/src/receipt/checks.rs`, `tap_core/src/receipt/receipt_sol.rs`, `tap_core/src/receipt/received_receipt.rs`, `tap_core/tests/escrow_test.rs`, `tap_core/tests/rav_test.rs`, `tap_core/tests/receipt_test.rs`, `tap_integration_tests/tests/indexer_mock.rs`, `tap_integration_tests/tests/showcase.rs`). [[1]](diffhunk://#diff-4700cc05800035245d6285f3d90fe2cfc81d2079ad7c00d84d0a6beb42bec352R140-L142) [[2]](diffhunk://#diff-5f58a31681fe4045a4617d48a08b08aa8156b340726aa3e8eddd9e8c85b4fb55L12-R13) [[3]](diffhunk://#diff-9bec0f019b96efce237e3daae0270dc96ae0cd02fe90a5ef22946f06d2ffea53L391-R403) [[4]](diffhunk://#diff-d446e6a99ccae05cfc383a0d74507646f7ed9dbf8269927d2c97784b95b70a10L7) [[5]](diffhunk://#diff-177ff019abd965bfefcf8a6236bcf75d4f9a74d1c95cf66018f91a82267971e5L13-R17) [[6]](diffhunk://#diff-e94ab5408a96a8b2f686c5f4041f87ef4b8bc676d3cf74509628cb7e73ac989cL7-R13) [[7]](diffhunk://#diff-0f9a9c13de05e8a29e131462c3eab0c90fcdf79336b935c9ac512a4ec27a6410R9-L19) [[8]](diffhunk://#diff-0f9a9c13de05e8a29e131462c3eab0c90fcdf79336b935c9ac512a4ec27a6410R266-R272) [[9]](diffhunk://#diff-0f9a9c13de05e8a29e131462c3eab0c90fcdf79336b935c9ac512a4ec27a6410L270-L274) [[10]](diffhunk://#diff-31111a5e355ef68e55fc0afb29d4d3cfcdd38b3a4a8f1e488fbdff1614c9e1feL44-R47) [[11]](diffhunk://#diff-ef8c3e0b9f1ddf2cd58bd9f9043483014ed6c4c978575b01d28964b3ceb3852eL4-R10) [[12]](diffhunk://#diff-9d6171b22bbbf5579cd278b52d0b5d7e188f7f84d3f492f54d5e52bb4a7e00d9L32-R43) [[13]](diffhunk://#diff-9d6171b22bbbf5579cd278b52d0b5d7e188f7f84d3f492f54d5e52bb4a7e00d9L203-R214) [[14]](diffhunk://#diff-076618f08754c730c7893c3d9b60e6b26a42e1c83c5f315d3cba952331bb1bfdL46-R53) [[15]](diffhunk://#diff-25b373fffff81706a939b331bd2e67e3d28f6da04da2ab7b4e1755bbd188cb02L18-R24) [[16]](diffhunk://#diff-b428953e78c6fa415c6aef939bf24cb0782c1f2cf3dc7a86346bd27250d2e57fL11) [[17]](diffhunk://#diff-e91f3312c173031f2a00ed60ab010a21393603535cb560439df634829d12c929L4-R21) [[18]](diffhunk://#diff-90628c3002c71a54aea727540e056aca6b06d98e84c322b7d297dd66c2e75b9fL1-R16) [[19]](diffhunk://#diff-e687c79a2ac078e01cc874bf2b33f00a3b4bd9d31596d549c0a2a264dfa4a6b9L17) [[20]](diffhunk://#diff-bd6d105ee5633d82595fd481ae92e61775d82591792ab01c2db9df299191d643L26)

### GitHub Actions workflow updates:

* Updated the `.github/workflows/tests.yml` file to use the latest versions of `actions/checkout` and `actions-rust-lang/setup-rust-toolchain`, and switched to using the nightly toolchain for formatting checks.

### Rust formatting improvements:

* Enabled nightly features required for formatting imports in `rustfmt.toml`, including `unstable_features`, `imports_granularity`, `group_imports`, and `reorder_modules`.