### PR TITLE
refactor!: manager generic over receipt

### DIFF
--- a/tap_aggregator/src/aggregator.rs
+++ b/tap_aggregator/src/aggregator.rs
@@ -44,7 +44,7 @@ pub fn check_and_aggregate_receipts(
     // Get the allocation id from the first receipt, return error if there are no receipts
     let allocation_id = match receipts.first() {
         Some(receipt) => receipt.message.allocation_id,
-        None => return Err(tap_core::Error::NoValidReceiptsForRAVRequest.into()),
+        None => return Err(tap_core::Error::NoValidReceiptsForRavRequest.into()),
     };
 
     // Check that the receipts all have the same allocation id

--- a/tap_core/src/error.rs
+++ b/tap_core/src/error.rs
@@ -46,7 +46,7 @@ pub enum Error {
     AdapterError { source_error: anyhow::Error },
     /// Error when no valid receipts are found for a RAV request
     #[error("Failed to produce rav request, no valid receipts")]
-    NoValidReceiptsForRAVRequest,
+    NoValidReceiptsForRavRequest,
 
     /// Error when the previous RAV allocation id does not match the allocation id from the new receipt
     #[error("Previous RAV allocation id ({prev_id}) doesn't match the allocation id from the new receipt ({new_id}).")]

--- a/tap_core/src/manager/adapters/receipt.rs
+++ b/tap_core/src/manager/adapters/receipt.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 
 use crate::receipt::{
     state::{Checking, ReceiptState},
-    ReceiptWithState,
+    ReceiptWithState, WithValueAndTimestamp,
 };
 
 /// Stores receipts in the storage.
@@ -16,7 +16,7 @@ use crate::receipt::{
 ///
 /// For example code see [crate::manager::context::memory::ReceiptStorage]
 #[async_trait]
-pub trait ReceiptStore {
+pub trait ReceiptStore<Rcpt> {
     /// Defines the user-specified error type.
     ///
     /// This error type should implement the `Error` and `Debug` traits from the standard library.
@@ -29,7 +29,7 @@ pub trait ReceiptStore {
     /// this process should be captured and returned as an `AdapterError`.
     async fn store_receipt(
         &self,
-        receipt: ReceiptWithState<Checking>,
+        receipt: ReceiptWithState<Checking, Rcpt>,
     ) -> Result<u64, Self::AdapterError>;
 }
 
@@ -62,7 +62,7 @@ pub trait ReceiptDelete {
 ///
 /// For example code see [crate::manager::context::memory::ReceiptStorage]
 #[async_trait]
-pub trait ReceiptRead {
+pub trait ReceiptRead<Rcpt> {
     /// Defines the user-specified error type.
     ///
     /// This error type should implement the `Error` and `Debug` traits from
@@ -92,15 +92,15 @@ pub trait ReceiptRead {
         &self,
         timestamp_range_ns: R,
         limit: Option<u64>,
-    ) -> Result<Vec<ReceiptWithState<Checking>>, Self::AdapterError>;
+    ) -> Result<Vec<ReceiptWithState<Checking, Rcpt>>, Self::AdapterError>;
 }
 
 /// See [`ReceiptRead::retrieve_receipts_in_timestamp_range()`] for details.
 ///
 /// WARNING: Will sort the receipts by timestamp using
 /// [vec::sort_unstable](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.sort_unstable).
-pub fn safe_truncate_receipts<T: ReceiptState>(
-    receipts: &mut Vec<ReceiptWithState<T>>,
+pub fn safe_truncate_receipts<T: ReceiptState, Rcpt: WithValueAndTimestamp>(
+    receipts: &mut Vec<ReceiptWithState<T, Rcpt>>,
     limit: u64,
 ) {
     if receipts.len() <= limit as usize {
@@ -110,18 +110,12 @@ pub fn safe_truncate_receipts<T: ReceiptState>(
         return;
     }
 
-    receipts.sort_unstable_by_key(|rx_receipt| rx_receipt.signed_receipt().message.timestamp_ns);
+    receipts.sort_unstable_by_key(|rx_receipt| rx_receipt.signed_receipt().timestamp_ns());
 
     // This one will be the last timestamp in `receipts` after naive truncation
-    let last_timestamp = receipts[limit as usize - 1]
-        .signed_receipt()
-        .message
-        .timestamp_ns;
+    let last_timestamp = receipts[limit as usize - 1].signed_receipt().timestamp_ns();
     // This one is the timestamp that comes just after the one above
-    let after_last_timestamp = receipts[limit as usize]
-        .signed_receipt()
-        .message
-        .timestamp_ns;
+    let after_last_timestamp = receipts[limit as usize].signed_receipt().timestamp_ns();
 
     receipts.truncate(limit as usize);
 
@@ -129,8 +123,6 @@ pub fn safe_truncate_receipts<T: ReceiptState>(
         // If the last timestamp is the same as the one that came after it, we need to
         // remove all the receipts with the same timestamp as the last one, because
         // otherwise we would leave behind part of the receipts for that timestamp.
-        receipts.retain(|rx_receipt| {
-            rx_receipt.signed_receipt().message.timestamp_ns != last_timestamp
-        });
+        receipts.retain(|rx_receipt| rx_receipt.signed_receipt().timestamp_ns() != last_timestamp);
     }
 }

--- a/tap_core/src/manager/mod.rs
+++ b/tap_core/src/manager/mod.rs
@@ -51,10 +51,10 @@
 //! struct MyContext;
 //!
 //! #[async_trait]
-//! impl ReceiptStore for MyContext {
+//! impl<T: Send + 'static> ReceiptStore<T> for MyContext {
 //!     type AdapterError = ReceiptError;
 //!
-//!     async fn store_receipt(&self, receipt: ReceiptWithState<Checking>) -> Result<u64, Self::AdapterError> {
+//!     async fn store_receipt(&self, receipt: ReceiptWithState<Checking, T>) -> Result<u64, Self::AdapterError> {
 //!         // ...
 //!         # Ok(0)
 //!     }

--- a/tap_core/src/manager/tap_manager.rs
+++ b/tap_core/src/manager/tap_manager.rs
@@ -7,7 +7,7 @@ use super::adapters::{
     RAVRead, RAVStore, ReceiptDelete, ReceiptRead, ReceiptStore, SignatureChecker,
 };
 use crate::{
-    rav::{RAVRequest, ReceiptAggregateVoucher, SignedRAV},
+    rav::{RavRequest, ReceiptAggregateVoucher, SignedRAV},
     receipt::{
         checks::{CheckBatch, CheckList, TimestampCheck, UniqueCheck},
         state::{Checked, Failed},
@@ -188,7 +188,7 @@ where
         ctx: &Context,
         timestamp_buffer_ns: u64,
         receipts_limit: Option<u64>,
-    ) -> Result<RAVRequest<SignedReceipt>, Error> {
+    ) -> Result<RavRequest<SignedReceipt>, Error> {
         let previous_rav = self.get_previous_rav().await?;
         let min_timestamp_ns = previous_rav
             .as_ref()
@@ -201,7 +201,7 @@ where
 
         let expected_rav = Self::generate_expected_rav(&valid_receipts, previous_rav.clone());
 
-        Ok(RAVRequest {
+        Ok(RavRequest {
             valid_receipts,
             previous_rav,
             invalid_receipts,
@@ -214,7 +214,7 @@ where
         previous_rav: Option<SignedRAV>,
     ) -> Result<ReceiptAggregateVoucher, Error> {
         if receipts.is_empty() {
-            return Err(Error::NoValidReceiptsForRAVRequest);
+            return Err(Error::NoValidReceiptsForRavRequest);
         }
         let allocation_id = receipts[0].signed_receipt().message.allocation_id;
         let receipts = receipts

--- a/tap_core/src/manager/tap_manager.rs
+++ b/tap_core/src/manager/tap_manager.rs
@@ -11,29 +11,34 @@ use crate::{
     receipt::{
         checks::{CheckBatch, CheckList, TimestampCheck, UniqueCheck},
         state::{Checked, Failed},
-        Context, ReceiptError, ReceiptWithState, SignedReceipt,
+        Context, ReceiptError, ReceiptWithState, SignedReceipt, WithUniqueId,
+        WithValueAndTimestamp,
     },
     Error,
 };
 
-pub struct Manager<E> {
+pub struct Manager<E, Rcpt> {
     /// Context that implements adapters
     context: E,
 
     /// Checks that must be completed for each receipt before being confirmed or denied for rav request
-    checks: CheckList,
+    checks: CheckList<Rcpt>,
 
     /// Struct responsible for doing checks for receipt. Ownership stays with manager allowing manager
     /// to update configuration ( like minimum timestamp ).
     domain_separator: Eip712Domain,
 }
 
-impl<E> Manager<E> {
+impl<E, Rcpt> Manager<E, Rcpt> {
     /// Creates new manager with provided `adapters`, any receipts received by this manager
     /// will complete all `required_checks` before being accepted or declined from RAV.
     /// `starting_min_timestamp` will be used as min timestamp until the first RAV request is created.
     ///
-    pub fn new(domain_separator: Eip712Domain, context: E, checks: impl Into<CheckList>) -> Self {
+    pub fn new(
+        domain_separator: Eip712Domain,
+        context: E,
+        checks: impl Into<CheckList<Rcpt>>,
+    ) -> Self {
         Self {
             context,
             domain_separator,
@@ -42,7 +47,7 @@ impl<E> Manager<E> {
     }
 }
 
-impl<E> Manager<E>
+impl<E, Rcpt> Manager<E, Rcpt>
 where
     E: RAVStore + SignatureChecker,
 {
@@ -79,7 +84,7 @@ where
     }
 }
 
-impl<E> Manager<E>
+impl<E, Rcpt> Manager<E, Rcpt>
 where
     E: RAVRead,
 {
@@ -95,9 +100,10 @@ where
     }
 }
 
-impl<E> Manager<E>
+impl<E, Rcpt> Manager<E, Rcpt>
 where
-    E: ReceiptRead + SignatureChecker,
+    E: ReceiptRead<Rcpt> + SignatureChecker,
+    Rcpt: WithUniqueId + WithValueAndTimestamp + Sync,
 {
     async fn collect_receipts(
         &self,
@@ -107,8 +113,8 @@ where
         limit: Option<u64>,
     ) -> Result<
         (
-            Vec<ReceiptWithState<Checked>>,
-            Vec<ReceiptWithState<Failed>>,
+            Vec<ReceiptWithState<Checked, Rcpt>>,
+            Vec<ReceiptWithState<Failed, Rcpt>>,
         ),
         Error,
     > {
@@ -156,9 +162,11 @@ where
     }
 }
 
-impl<E> Manager<E>
+// TODO make create_rav_request generic over receipt
+impl<E> Manager<E, SignedReceipt>
 where
-    E: ReceiptRead + RAVRead + SignatureChecker,
+    E: ReceiptRead<SignedReceipt> + RAVRead + SignatureChecker,
+    //Rcpt: WithUniqueId + WithValueAndTimestamp + Sync,
 {
     /// Completes remaining checks on all receipts up to
     /// (current time - `timestamp_buffer_ns`). Returns them in two lists
@@ -180,7 +188,7 @@ where
         ctx: &Context,
         timestamp_buffer_ns: u64,
         receipts_limit: Option<u64>,
-    ) -> Result<RAVRequest, Error> {
+    ) -> Result<RAVRequest<SignedReceipt>, Error> {
         let previous_rav = self.get_previous_rav().await?;
         let min_timestamp_ns = previous_rav
             .as_ref()
@@ -202,7 +210,7 @@ where
     }
 
     fn generate_expected_rav(
-        receipts: &[ReceiptWithState<Checked>],
+        receipts: &[ReceiptWithState<Checked, SignedReceipt>],
         previous_rav: Option<SignedRAV>,
     ) -> Result<ReceiptAggregateVoucher, Error> {
         if receipts.is_empty() {
@@ -221,7 +229,7 @@ where
     }
 }
 
-impl<E> Manager<E>
+impl<E, Rcpt> Manager<E, Rcpt>
 where
     E: ReceiptDelete + RAVRead,
 {
@@ -251,9 +259,9 @@ where
     }
 }
 
-impl<E> Manager<E>
+impl<E, Rcpt> Manager<E, Rcpt>
 where
-    E: ReceiptStore,
+    E: ReceiptStore<Rcpt>,
 {
     /// Runs `initial_checks` on `signed_receipt` for initial verification,
     /// then stores received receipt.
@@ -266,7 +274,7 @@ where
     pub async fn verify_and_store_receipt(
         &self,
         ctx: &Context,
-        signed_receipt: SignedReceipt,
+        signed_receipt: Rcpt,
     ) -> std::result::Result<(), Error> {
         let mut received_receipt = ReceiptWithState::new(signed_receipt);
 

--- a/tap_core/src/rav.rs
+++ b/tap_core/src/rav.rs
@@ -48,7 +48,7 @@ use crate::{receipt::Receipt, signed_message::EIP712SignedMessage, Error};
 
 /// EIP712 signed message for ReceiptAggregateVoucher
 pub type SignedRAV = EIP712SignedMessage<ReceiptAggregateVoucher>;
-pub use request::RAVRequest;
+pub use request::RavRequest;
 
 sol! {
     /// Holds information needed for promise of payment signed with ECDSA

--- a/tap_core/src/rav/request.rs
+++ b/tap_core/src/rav/request.rs
@@ -12,13 +12,13 @@ use crate::{
 
 /// Request to `tap_aggregator` to aggregate receipts into a Signed RAV.
 #[derive(Debug)]
-pub struct RAVRequest {
+pub struct RAVRequest<Rcpt> {
     /// List of checked and reserved receipts to aggregate
-    pub valid_receipts: Vec<ReceiptWithState<Checked>>,
+    pub valid_receipts: Vec<ReceiptWithState<Checked, Rcpt>>,
     /// Optional previous RAV to aggregate with
     pub previous_rav: Option<SignedRAV>,
     /// List of failed receipt used to log invalid receipts
-    pub invalid_receipts: Vec<ReceiptWithState<Failed>>,
+    pub invalid_receipts: Vec<ReceiptWithState<Failed, Rcpt>>,
     /// Expected RAV to be created
     pub expected_rav: Result<ReceiptAggregateVoucher, Error>,
 }

--- a/tap_core/src/rav/request.rs
+++ b/tap_core/src/rav/request.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// Request to `tap_aggregator` to aggregate receipts into a Signed RAV.
 #[derive(Debug)]
-pub struct RAVRequest<Rcpt> {
+pub struct RavRequest<Rcpt> {
     /// List of checked and reserved receipts to aggregate
     pub valid_receipts: Vec<ReceiptWithState<Checked, Rcpt>>,
     /// Optional previous RAV to aggregate with

--- a/tap_core/src/receipt/mod.rs
+++ b/tap_core/src/receipt/mod.rs
@@ -38,3 +38,13 @@ pub type SignedReceipt = EIP712SignedMessage<Receipt>;
 pub type ReceiptResult<T> = Result<T, ReceiptError>;
 
 pub type Context = anymap3::Map<dyn std::any::Any + Send + Sync>;
+
+pub trait WithValueAndTimestamp {
+    fn value(&self) -> u128;
+    fn timestamp_ns(&self) -> u64;
+}
+
+pub trait WithUniqueId {
+    type Output: Eq + std::hash::Hash;
+    fn unique_id(&self) -> Self::Output;
+}

--- a/tap_core/src/receipt/receipt_sol.rs
+++ b/tap_core/src/receipt/receipt_sol.rs
@@ -12,6 +12,8 @@ use alloy::{primitives::Address, sol};
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 
+use super::WithValueAndTimestamp;
+
 sol! {
     /// Holds information needed for promise of payment signed with ECDSA
     #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -38,6 +40,16 @@ impl Receipt {
             nonce,
             value,
         })
+    }
+}
+
+impl WithValueAndTimestamp for Receipt {
+    fn value(&self) -> u128 {
+        self.value
+    }
+
+    fn timestamp_ns(&self) -> u64 {
+        self.timestamp_ns
     }
 }
 

--- a/tap_core/src/signed_message.rs
+++ b/tap_core/src/signed_message.rs
@@ -33,7 +33,10 @@ use alloy::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::Result;
+use crate::{
+    receipt::{WithUniqueId, WithValueAndTimestamp},
+    Result,
+};
 
 /// EIP712 signed message
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -113,5 +116,29 @@ impl<M: SolStruct> EIP712SignedMessage<M> {
     /// Use this a simple key for testing
     pub fn unique_hash(&self) -> MessageId {
         MessageId(self.message.eip712_hash_struct().into())
+    }
+}
+
+impl<M> WithUniqueId for EIP712SignedMessage<M>
+where
+    M: SolStruct,
+{
+    type Output = SignatureBytes;
+
+    fn unique_id(&self) -> Self::Output {
+        self.signature.get_signature_bytes()
+    }
+}
+
+impl<T> WithValueAndTimestamp for EIP712SignedMessage<T>
+where
+    T: WithValueAndTimestamp + SolStruct,
+{
+    fn value(&self) -> u128 {
+        self.message.value()
+    }
+
+    fn timestamp_ns(&self) -> u64 {
+        self.message.timestamp_ns()
     }
 }

--- a/tap_core/tests/receipt_test.rs
+++ b/tap_core/tests/receipt_test.rs
@@ -12,7 +12,9 @@ use rand::thread_rng;
 use rstest::*;
 use tap_core::{
     manager::{adapters::ReceiptStore, context::memory::InMemoryContext},
-    receipt::{checks::StatefulTimestampCheck, state::Checking, Receipt, ReceiptWithState},
+    receipt::{
+        checks::StatefulTimestampCheck, state::Checking, Receipt, ReceiptWithState, SignedReceipt,
+    },
     signed_message::EIP712SignedMessage,
     tap_eip712_domain,
 };
@@ -159,7 +161,7 @@ fn safe_truncate_receipts_test(
     let wallet = PrivateKeySigner::random();
 
     // Vec of (id, receipt)
-    let mut receipts_orig: Vec<ReceiptWithState<Checking>> = Vec::new();
+    let mut receipts_orig: Vec<ReceiptWithState<Checking, SignedReceipt>> = Vec::new();
 
     for timestamp in input.iter() {
         // The contents of the receipt only need to be unique for this test (so we can check)

--- a/tap_core/tests/received_receipt_test.rs
+++ b/tap_core/tests/received_receipt_test.rs
@@ -13,7 +13,7 @@ use tap_core::{
     manager::context::memory::{checks::get_full_list_of_checks, EscrowStorage, QueryAppraisals},
     receipt::{
         checks::{ReceiptCheck, StatefulTimestampCheck},
-        Context, Receipt, ReceiptWithState,
+        Context, Receipt, ReceiptWithState, SignedReceipt,
     },
     signed_message::EIP712SignedMessage,
     tap_eip712_domain,
@@ -56,7 +56,7 @@ fn domain_separator() -> Eip712Domain {
 struct ContextFixture {
     escrow_storage: EscrowStorage,
     query_appraisals: QueryAppraisals,
-    checks: Vec<ReceiptCheck>,
+    checks: Vec<ReceiptCheck<SignedReceipt>>,
     signer: PrivateKeySigner,
 }
 

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -29,7 +29,7 @@ use tap_core::{
     rav::SignedRAV,
     receipt::{
         checks::{CheckList, StatefulTimestampCheck},
-        Receipt,
+        Receipt, SignedReceipt,
     },
     signed_message::{EIP712SignedMessage, MessageId},
     tap_eip712_domain,
@@ -161,7 +161,7 @@ fn query_appraisals(query_price: &[u128]) -> QueryAppraisals {
 
 struct ContextFixture {
     context: InMemoryContext,
-    checks: CheckList,
+    checks: CheckList<SignedReceipt>,
 }
 
 #[fixture]
@@ -800,7 +800,7 @@ async fn start_indexer_server(
     mut context: InMemoryContext,
     sender_id: Address,
     available_escrow: u128,
-    required_checks: CheckList,
+    required_checks: CheckList<SignedReceipt>,
     receipt_threshold: u64,
     agg_server_addr: SocketAddr,
 ) -> Result<(ServerHandle, SocketAddr)> {


### PR DESCRIPTION
- Add new Traits WithUniqueId and WithValueAndTimestamp
- implement WithUniqueId and WithValueAndTimestamp for SignedReceipt
- ReceiptWithState generic over the receipt
- RAVRequest generic over receipt
- Manager generic over receipt (can only collect receipts for SignedReceipt for now)
- Checklist generic over receipt
- Functions that previously needed timestamp_ns and value from receipt now uses generic with WithValueAndTimestamp bounds