### PR TITLE
ci: remove sudo from protobuf install

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install protobuf-compiler -y
+        run: apt-get update && apt-get install protobuf-compiler -y
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
By changing to Rust image, sudo is not available (possibly because it has root permission)

https://github.com/semiotic-ai/timeline-aggregation-protocol/actions/runs/13036335498/job/36367623892