### PR TITLE
chore(deps): use thegraph-core's re-exported alloy dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ license = "Apache-2.0"
 repository = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
 
 [workspace.dependencies]
-alloy = { version = "0.11.0", features = ["full"] }
 serde = { version = "1.0.217", features = ["derive"] }
 rstest = "0.24.0"
 anyhow = { version = "1.0.95" }
@@ -25,4 +24,5 @@ rand = "0.8.5"
 jsonrpsee = { version = "0.24.7", features = ["macros", "server"] }
 insta = { version = "1.42.0", features = ["json"] }
 serde_json = { version = "1.0.137", features = ["raw_value"] }
+thegraph-core = "0.12.0"
 thiserror = "2.0.11"

--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -12,8 +12,6 @@ name = "tap_aggregator"
 path = "src/main.rs"
 
 [dependencies]
-alloy.workspace = true
-alloy-sol-types ={ version = "0.8.21", features = ["eip712-serde"]}
 anyhow.workspace = true
 axum = { version = "0.7.5", features = [
     "http1",
@@ -36,6 +34,7 @@ serde.workspace = true
 serde_json.workspace = true
 strum = { version = "0.26.3", features = ["derive"] }
 tap_core = { path = "../tap_core", version = "3.0.1" }
+thegraph-core = { workspace = true, features = ["alloy-eip712"] }
 tokio.workspace = true
 tonic = { version = "0.12.3", features = ["transport", "zstd"] }
 tower = { version = "0.5.2", features = ["util", "steer"] }

--- a/tap_aggregator/src/aggregator/v1.rs
+++ b/tap_aggregator/src/aggregator/v1.rs
@@ -3,14 +3,14 @@
 
 use std::collections::{hash_set, HashSet};
 
-use alloy::{
-    dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
-    sol_types::SolStruct,
-};
 use anyhow::{bail, Ok, Result};
 use rayon::prelude::*;
 use tap_core::signed_message::{Eip712SignedMessage, SignatureBytes, SignatureBytesExt};
 use tap_graph::{Receipt, ReceiptAggregateVoucher};
+use thegraph_core::alloy::{
+    dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+    sol_types::SolStruct,
+};
 
 pub fn check_and_aggregate_receipts(
     domain_separator: &Eip712Domain,
@@ -132,10 +132,12 @@ fn check_receipt_timestamps(
 mod tests {
     use std::str::FromStr;
 
-    use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
     use rstest::*;
     use tap_core::{signed_message::Eip712SignedMessage, tap_eip712_domain};
     use tap_graph::{Receipt, ReceiptAggregateVoucher};
+    use thegraph_core::alloy::{
+        dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+    };
 
     use super::*;
 

--- a/tap_aggregator/src/aggregator/v2.rs
+++ b/tap_aggregator/src/aggregator/v2.rs
@@ -3,14 +3,14 @@
 
 use std::collections::{hash_set, HashSet};
 
-use alloy::{
-    dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
-    sol_types::SolStruct,
-};
 use anyhow::{bail, Ok, Result};
 use rayon::prelude::*;
 use tap_core::signed_message::{Eip712SignedMessage, SignatureBytes, SignatureBytesExt};
 use tap_graph::v2::{Receipt, ReceiptAggregateVoucher};
+use thegraph_core::alloy::{
+    dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+    sol_types::SolStruct,
+};
 
 pub fn check_and_aggregate_receipts(
     domain_separator: &Eip712Domain,
@@ -185,14 +185,14 @@ fn check_receipt_timestamps(
 
 #[cfg(test)]
 mod tests {
-    use alloy::{
+    use rstest::*;
+    use tap_core::{signed_message::Eip712SignedMessage, tap_eip712_domain};
+    use tap_graph::v2::{Receipt, ReceiptAggregateVoucher};
+    use thegraph_core::alloy::{
         dyn_abi::Eip712Domain,
         primitives::{address, Address, Bytes},
         signers::local::PrivateKeySigner,
     };
-    use rstest::*;
-    use tap_core::{signed_message::Eip712SignedMessage, tap_eip712_domain};
-    use tap_graph::v2::{Receipt, ReceiptAggregateVoucher};
 
     #[fixture]
     fn keys() -> (PrivateKeySigner, Address) {

--- a/tap_aggregator/src/grpc.rs
+++ b/tap_aggregator/src/grpc.rs
@@ -141,9 +141,9 @@ pub mod v1 {
 }
 
 pub mod v2 {
-    use alloy::primitives::Bytes;
     use anyhow::anyhow;
     use tap_core::signed_message::Eip712SignedMessage;
+    use thegraph_core::alloy::primitives::Bytes;
 
     tonic::include_proto!("tap_aggregator.v2");
 

--- a/tap_aggregator/src/main.rs
+++ b/tap_aggregator/src/main.rs
@@ -5,12 +5,14 @@
 
 use std::{collections::HashSet, str::FromStr};
 
-use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 use anyhow::Result;
 use clap::Parser;
 use log::{debug, info};
 use tap_aggregator::{metrics, server};
 use tap_core::tap_eip712_domain;
+use thegraph_core::alloy::{
+    dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -141,7 +143,7 @@ async fn main() -> Result<()> {
 }
 
 fn create_eip712_domain(args: &Args) -> Result<Eip712Domain> {
-    // Transfrom the args into the types expected by Eip712Domain::new().
+    // Transform the args into the types expected by Eip712Domain::new().
 
     // Transform optional strings into optional Cow<str>.
     // Transform optional strings into optional U256.

--- a/tap_aggregator/src/server.rs
+++ b/tap_aggregator/src/server.rs
@@ -3,7 +3,6 @@
 
 use std::{collections::HashSet, str::FromStr};
 
-use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 use anyhow::Result;
 use axum::{error_handling::HandleError, routing::post_service, BoxError, Router};
 use hyper::StatusCode;
@@ -16,6 +15,9 @@ use log::{error, info};
 use prometheus::{register_counter, register_int_counter, Counter, IntCounter};
 use tap_core::signed_message::Eip712SignedMessage;
 use tap_graph::{Receipt, ReceiptAggregateVoucher, SignedReceipt};
+use thegraph_core::alloy::{
+    dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+};
 use tokio::{net::TcpListener, signal, task::JoinHandle};
 use tonic::{codec::CompressionEncoding, service::Routes, Request, Response, Status};
 use tower::{layer::util::Identity, make::Shared};
@@ -493,12 +495,14 @@ fn produce_kafka_records(
 mod tests {
     use std::{collections::HashSet, str::FromStr};
 
-    use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
     use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
     use rand::{prelude::*, seq::SliceRandom};
     use rstest::*;
     use tap_core::{signed_message::Eip712SignedMessage, tap_eip712_domain};
     use tap_graph::{Receipt, ReceiptAggregateVoucher};
+    use thegraph_core::alloy::{
+        dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+    };
 
     use crate::server;
 

--- a/tap_aggregator/tests/aggregate_test.rs
+++ b/tap_aggregator/tests/aggregate_test.rs
@@ -3,7 +3,6 @@
 
 use std::{collections::HashSet, str::FromStr};
 
-use alloy::{primitives::Address, signers::local::PrivateKeySigner};
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use tap_aggregator::{
     grpc::v1::{tap_aggregator_client::TapAggregatorClient, RavRequest},
@@ -12,6 +11,7 @@ use tap_aggregator::{
 };
 use tap_core::{signed_message::Eip712SignedMessage, tap_eip712_domain};
 use tap_graph::{Receipt, ReceiptAggregateVoucher};
+use thegraph_core::alloy::{primitives::Address, signers::local::PrivateKeySigner};
 use tonic::codec::CompressionEncoding;
 
 #[tokio::test]

--- a/tap_aggregator/tests/aggregate_v1_and_v2.rs
+++ b/tap_aggregator/tests/aggregate_v1_and_v2.rs
@@ -3,10 +3,6 @@
 
 use std::collections::HashSet;
 
-use alloy::{
-    primitives::{address, Address},
-    signers::local::PrivateKeySigner,
-};
 use tap_aggregator::{
     grpc::{
         v1::{tap_aggregator_client::TapAggregatorClient as ClientV1, RavRequest as ReqV1},
@@ -16,6 +12,10 @@ use tap_aggregator::{
 };
 use tap_core::{signed_message::Eip712SignedMessage, tap_eip712_domain};
 use tap_graph::{v2::Receipt as ReceiptV2, Receipt as ReceiptV1};
+use thegraph_core::alloy::{
+    primitives::{address, Address},
+    signers::local::PrivateKeySigner,
+};
 use tonic::codec::CompressionEncoding;
 
 #[tokio::test]

--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -8,21 +8,22 @@ readme = "README.md"
 description = "Core Timeline Aggregation Protocol library: a fast, efficient and trustless unidirectional micro-payments system."
 
 [dependencies]
-alloy.workspace = true
 anyhow.workspace = true
 async-trait = "0.1.85"
 rand.workspace = true
-thiserror.workspace = true
-tokio.workspace = true
-tap_receipt = { version = "0.1.0", path = "../tap_receipt" }
 tap_eip712_message = { version = "0.1.0", path = "../tap_eip712_message" }
 tap_graph = { version = "0.2.0", path = "../tap_graph", optional = true }
+tap_receipt = { version = "0.1.0", path = "../tap_receipt" }
+thegraph-core.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_std"] }
 insta.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
+thegraph-core = { workspace = true, features = ["alloy-signer-mnemonic"] }
 
 [features]
 default = ["in_memory"]

--- a/tap_core/benches/timeline_aggretion_protocol_benchmark.rs
+++ b/tap_core/benches/timeline_aggretion_protocol_benchmark.rs
@@ -10,10 +10,12 @@
 
 use std::str::FromStr;
 
-use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tap_core::{signed_message::Eip712SignedMessage, tap_eip712_domain};
 use tap_graph::{Receipt, ReceiptAggregateVoucher};
+use thegraph_core::alloy::{
+    dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+};
 
 pub fn create_and_sign_receipt(
     domain_separator: &Eip712Domain,

--- a/tap_core/src/error.rs
+++ b/tap_core/src/error.rs
@@ -6,7 +6,7 @@
 
 use std::result::Result as StdResult;
 
-use alloy::primitives::Address;
+use thegraph_core::alloy::primitives::Address;
 use thiserror::Error as ThisError;
 
 use crate::receipt::ReceiptError;
@@ -22,7 +22,7 @@ pub enum Error {
     InvalidSystemTime { source_error_message: String },
     /// `alloy` wallet error
     #[error(transparent)]
-    WalletError(#[from] alloy::signers::Error),
+    WalletError(#[from] thegraph_core::alloy::signers::Error),
 
     /// `alloy` wallet error
     #[error(transparent)]

--- a/tap_core/src/lib.rs
+++ b/tap_core/src/lib.rs
@@ -8,7 +8,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use alloy::{dyn_abi::Eip712Domain, sol_types::eip712_domain};
+use thegraph_core::alloy::{dyn_abi::Eip712Domain, primitives::Address, sol_types::eip712_domain};
 use thiserror::Error;
 
 mod error;
@@ -44,10 +44,7 @@ fn get_current_timestamp_u64_ns() -> Result<u64> {
 /// - `version`: "1"
 /// - `chain_id`: The chain ID of the chain where the domain separator is deployed.
 /// - `verifying_contract`: The address of the contract that is verifying the signature.
-pub fn tap_eip712_domain(
-    chain_id: u64,
-    verifying_contract_address: alloy::primitives::Address,
-) -> Eip712Domain {
+pub fn tap_eip712_domain(chain_id: u64, verifying_contract_address: Address) -> Eip712Domain {
     eip712_domain! {
         name: "TAP",
         version: "1",
@@ -60,9 +57,11 @@ pub fn tap_eip712_domain(
 mod tap_tests {
     use std::str::FromStr;
 
-    use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
     use rstest::*;
     use tap_graph::{Receipt, ReceiptAggregateVoucher};
+    use thegraph_core::alloy::{
+        dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+    };
 
     use crate::{signed_message::Eip712SignedMessage, tap_eip712_domain};
 

--- a/tap_core/src/manager/adapters/rav.rs
+++ b/tap_core/src/manager/adapters/rav.rs
@@ -1,8 +1,8 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy::sol_types::SolStruct;
 use async_trait::async_trait;
+use thegraph_core::alloy::sol_types::SolStruct;
 
 use crate::signed_message::Eip712SignedMessage;
 

--- a/tap_core/src/manager/adapters/signature.rs
+++ b/tap_core/src/manager/adapters/signature.rs
@@ -1,8 +1,8 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy::{dyn_abi::Eip712Domain, primitives::Address, sol_types::SolStruct};
 use async_trait::async_trait;
+use thegraph_core::alloy::{dyn_abi::Eip712Domain, primitives::Address, sol_types::SolStruct};
 
 use crate::{signed_message::Eip712SignedMessage, Error};
 

--- a/tap_core/src/manager/context/memory.rs
+++ b/tap_core/src/manager/context/memory.rs
@@ -12,9 +12,9 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use alloy::primitives::Address;
 use async_trait::async_trait;
 use tap_graph::{ReceiptAggregateVoucher, SignedRav, SignedReceipt};
+use thegraph_core::alloy::primitives::Address;
 
 use crate::{
     manager::adapters::*,
@@ -258,8 +258,8 @@ pub mod checks {
         sync::{Arc, RwLock},
     };
 
-    use alloy::{dyn_abi::Eip712Domain, primitives::Address};
     use tap_graph::SignedReceipt;
+    use thegraph_core::alloy::{dyn_abi::Eip712Domain, primitives::Address};
 
     use crate::{
         receipt::{

--- a/tap_core/src/manager/mod.rs
+++ b/tap_core/src/manager/mod.rs
@@ -59,9 +59,9 @@
 //!         # Ok(0)
 //!     }
 //! }
-//! # #[tokio::main]
+//! # #[tokio::main(flavor = "current_thread")]
 //! # async fn main() {
-//! # use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
+//! # use thegraph_core::alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 //! # use tap_graph::{Receipt, SignedReceipt};
 //! # use tap_core::signed_message::Eip712SignedMessage;
 //! # let domain_separator = Eip712Domain::default();

--- a/tap_core/src/manager/tap_manager.rs
+++ b/tap_core/src/manager/tap_manager.rs
@@ -1,8 +1,8 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy::{dyn_abi::Eip712Domain, sol_types::SolStruct};
 use tap_receipt::rav::Aggregate;
+use thegraph_core::alloy::{dyn_abi::Eip712Domain, sol_types::SolStruct};
 
 use super::adapters::{
     RavRead, RavStore, ReceiptDelete, ReceiptRead, ReceiptStore, SignatureChecker,

--- a/tap_core/src/rav_request.rs
+++ b/tap_core/src/rav_request.rs
@@ -3,8 +3,8 @@
 
 //! Request to Tap Aggregator
 
-use alloy::sol_types::SolStruct;
 use tap_receipt::rav::AggregationError;
+use thegraph_core::alloy::sol_types::SolStruct;
 
 use crate::{
     receipt::{

--- a/tap_core/src/signed_message.rs
+++ b/tap_core/src/signed_message.rs
@@ -8,7 +8,7 @@
 //!
 //! # Example
 //! ```rust
-//! # use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
+//! # use thegraph_core::alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 //! # use tap_graph::{Receipt};
 //! # let domain_separator = Eip712Domain::default();
 //! use tap_core::signed_message::Eip712SignedMessage;

--- a/tap_core/tests/manager_test.rs
+++ b/tap_core/tests/manager_test.rs
@@ -7,9 +7,11 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 use anyhow::anyhow;
 use rstest::*;
+use thegraph_core::alloy::{
+    dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+};
 
 fn get_current_timestamp_u64_ns() -> anyhow::Result<u64> {
     Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos() as u64)

--- a/tap_core/tests/rav_test.rs
+++ b/tap_core/tests/rav_test.rs
@@ -7,12 +7,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-#[allow(deprecated)]
-use alloy::primitives::{Address, PrimitiveSignature, Signature};
-use alloy::{
-    dyn_abi::Eip712Domain,
-    signers::local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner},
-};
 use rstest::*;
 use tap_core::{
     manager::{
@@ -24,6 +18,12 @@ use tap_core::{
     tap_eip712_domain,
 };
 use tap_graph::{Receipt, ReceiptAggregateVoucher};
+#[allow(deprecated)]
+use thegraph_core::alloy::primitives::{Address, PrimitiveSignature, Signature};
+use thegraph_core::alloy::{
+    dyn_abi::Eip712Domain,
+    signers::local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner},
+};
 
 #[fixture]
 fn domain_separator() -> Eip712Domain {

--- a/tap_core/tests/receipt_test.rs
+++ b/tap_core/tests/receipt_test.rs
@@ -7,7 +7,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 use rand::{seq::SliceRandom, thread_rng};
 use rstest::*;
 use tap_core::{
@@ -17,6 +16,9 @@ use tap_core::{
     tap_eip712_domain,
 };
 use tap_graph::{Receipt, SignedReceipt};
+use thegraph_core::alloy::{
+    dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+};
 
 #[fixture]
 fn domain_separator() -> Eip712Domain {

--- a/tap_core/tests/received_receipt_test.rs
+++ b/tap_core/tests/received_receipt_test.rs
@@ -7,7 +7,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 use rstest::*;
 use tap_core::{
     manager::context::memory::{checks::get_full_list_of_checks, EscrowStorage, QueryAppraisals},
@@ -19,6 +18,9 @@ use tap_core::{
     tap_eip712_domain,
 };
 use tap_graph::{Receipt, SignedReceipt};
+use thegraph_core::alloy::{
+    dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
+};
 
 #[fixture]
 fn signer() -> PrivateKeySigner {

--- a/tap_eip712_message/Cargo.toml
+++ b/tap_eip712_message/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 description = "EIP712 singed messages used by TAP"
 
 [dependencies]
-alloy.workspace = true
 serde.workspace = true
+thegraph-core.workspace = true
 thiserror.workspace = true
 
 

--- a/tap_eip712_message/src/lib.rs
+++ b/tap_eip712_message/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! # Example
 //! ```rust
-//! # use alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
+//! # use thegraph_core::alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 //! # let domain_separator = Eip712Domain::default();
 //! use tap_eip712_message::Eip712SignedMessage;
 //! # let wallet = PrivateKeySigner::random();
@@ -22,24 +22,24 @@
 //! ```
 //!
 
-use alloy::{
+use serde::{Deserialize, Serialize};
+use thegraph_core::alloy::{
     dyn_abi::Eip712Domain,
     primitives::{Address, PrimitiveSignature as Signature},
     signers::{local::PrivateKeySigner, SignerSync},
     sol_types::SolStruct,
 };
-use serde::{Deserialize, Serialize};
 
 /// Errors returned by creation of messages and verify signature
 #[derive(thiserror::Error, Debug)]
 pub enum Eip712Error {
     /// `alloy` wallet error
     #[error(transparent)]
-    WalletError(#[from] alloy::signers::Error),
+    WalletError(#[from] thegraph_core::alloy::signers::Error),
 
     /// `alloy` signature error
     #[error(transparent)]
-    SignatureError(#[from] alloy::primitives::SignatureError),
+    SignatureError(#[from] thegraph_core::alloy::primitives::SignatureError),
 }
 
 /// EIP712 signed message

--- a/tap_graph/Cargo.toml
+++ b/tap_graph/Cargo.toml
@@ -7,11 +7,11 @@ repository.workspace = true
 description = "The Graph TAP receipt structs"
 
 [dependencies]
-alloy.workspace = true
-serde.workspace = true
 rand.workspace = true
+serde.workspace = true
 tap_eip712_message = { version = "0.1.0", path = "../tap_eip712_message" }
 tap_receipt = { version = "0.1.0", path = "../tap_receipt" }
+thegraph-core.workspace = true
 
 
 [dev-dependencies]

--- a/tap_graph/src/v1/rav.rs
+++ b/tap_graph/src/v1/rav.rs
@@ -39,7 +39,6 @@
 
 use std::cmp;
 
-use alloy::{primitives::Address, sol};
 use serde::{Deserialize, Serialize};
 use tap_eip712_message::Eip712SignedMessage;
 use tap_receipt::{
@@ -47,6 +46,7 @@ use tap_receipt::{
     state::Checked,
     ReceiptWithState, WithValueAndTimestamp,
 };
+use thegraph_core::alloy::{primitives::Address, sol};
 
 use super::{Receipt, SignedReceipt};
 

--- a/tap_graph/src/v1/receipt.rs
+++ b/tap_graph/src/v1/receipt.rs
@@ -10,11 +10,11 @@
 
 use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
-use alloy::{primitives::Address, sol};
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use tap_eip712_message::Eip712SignedMessage;
 use tap_receipt::WithValueAndTimestamp;
+use thegraph_core::alloy::{primitives::Address, sol};
 
 /// A Receipt wrapped in an Eip712SignedMessage
 pub type SignedReceipt = Eip712SignedMessage<Receipt>;

--- a/tap_graph/src/v2/rav.rs
+++ b/tap_graph/src/v2/rav.rs
@@ -5,16 +5,16 @@
 
 use std::cmp;
 
-use alloy::{
-    primitives::{Address, Bytes},
-    sol,
-};
 use serde::{Deserialize, Serialize};
 use tap_eip712_message::Eip712SignedMessage;
 use tap_receipt::{
     rav::{Aggregate, AggregationError},
     state::Checked,
     ReceiptWithState, WithValueAndTimestamp,
+};
+use thegraph_core::alloy::{
+    primitives::{Address, Bytes},
+    sol,
 };
 
 use super::{Receipt, SignedReceipt};

--- a/tap_graph/src/v2/receipt.rs
+++ b/tap_graph/src/v2/receipt.rs
@@ -5,11 +5,11 @@
 
 use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
-use alloy::{primitives::Address, sol};
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use tap_eip712_message::Eip712SignedMessage;
 use tap_receipt::WithValueAndTimestamp;
+use thegraph_core::alloy::{primitives::Address, sol};
 
 /// A signed receipt message
 pub type SignedReceipt = Eip712SignedMessage<Receipt>;
@@ -77,8 +77,8 @@ impl WithValueAndTimestamp for Receipt {
 mod receipt_unit_test {
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use alloy::primitives::address;
     use rstest::*;
+    use thegraph_core::alloy::primitives::address;
 
     use super::*;
 

--- a/tap_integration_tests/Cargo.toml
+++ b/tap_integration_tests/Cargo.toml
@@ -13,15 +13,15 @@ tap_aggregator = { path = "../tap_aggregator" }
 tap_core = { path = "../tap_core", version = "3.0.1" }
 rand.workspace = true
 anyhow.workspace = true
+thegraph-core.workspace = true
 tokio.workspace = true
-alloy.workspace = true
 jsonrpsee = { workspace = true, features = ["jsonrpsee-http-client"] }
 jsonrpsee-core = "0.24.7"
 tap_graph = { path = "../tap_graph" }
 
 [dev-dependencies]
 rstest.workspace = true
-alloy = { workspace = true, features = ["signer-mnemonic"] }
+thegraph-core = { workspace = true, features = ["alloy-signer-mnemonic"] }
 
 [[test]]
 name = "integration_tests"

--- a/tap_integration_tests/tests/indexer_mock.rs
+++ b/tap_integration_tests/tests/indexer_mock.rs
@@ -5,7 +5,6 @@ use std::sync::{
     Arc,
 };
 
-use alloy::dyn_abi::Eip712Domain;
 use anyhow::{Error, Result};
 use jsonrpsee::{
     core::async_trait,
@@ -24,6 +23,7 @@ use tap_core::{
     receipt::{checks::CheckList, Context},
 };
 use tap_graph::{ReceiptAggregateVoucher, SignedRav, SignedReceipt};
+use thegraph_core::alloy::dyn_abi::Eip712Domain;
 /// Rpc trait represents a JSON-RPC server that has a single async method `request`.
 /// This method is designed to handle incoming JSON-RPC requests.
 #[rpc(server)]

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -12,11 +12,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use alloy::{
-    dyn_abi::Eip712Domain,
-    primitives::Address,
-    signers::local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner},
-};
 use anyhow::{Error, Result};
 use jsonrpsee::{
     core::client::ClientT, http_client::HttpClientBuilder, rpc_params, server::ServerHandle,
@@ -31,6 +26,11 @@ use tap_core::{
     tap_eip712_domain,
 };
 use tap_graph::{Receipt, SignedRav, SignedReceipt};
+use thegraph_core::alloy::{
+    dyn_abi::Eip712Domain,
+    primitives::Address,
+    signers::local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner},
+};
 use tokio::task::JoinHandle;
 
 use crate::indexer_mock;

--- a/tap_receipt/Cargo.toml
+++ b/tap_receipt/Cargo.toml
@@ -7,13 +7,13 @@ repository.workspace = true
 description = "TAP Receipt states and checks"
 
 [dependencies]
-alloy.workspace = true
 anyhow.workspace = true
 anymap3 = "1.0.1"
-thiserror.workspace = true
-serde.workspace = true
 async-trait = "0.1.85"
+serde.workspace = true
 tap_eip712_message = { version = "0.1.0", path = "../tap_eip712_message" }
+thegraph-core.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/tap_receipt/src/checks.rs
+++ b/tap_receipt/src/checks.rs
@@ -211,11 +211,11 @@ where
 mod tests {
     use std::time::{Duration, SystemTime};
 
-    use alloy::{
+    use tap_eip712_message::Eip712SignedMessage;
+    use thegraph_core::alloy::{
         dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner, sol,
         sol_types::eip712_domain,
     };
-    use tap_eip712_message::Eip712SignedMessage;
 
     use super::*;
 

--- a/tap_receipt/src/error.rs
+++ b/tap_receipt/src/error.rs
@@ -1,8 +1,8 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use alloy::primitives::Address;
 use serde::{Deserialize, Serialize};
+use thegraph_core::alloy::primitives::Address;
 
 /// Error type for receipts
 #[derive(thiserror::Error, Debug, Clone, Serialize, Deserialize)]

--- a/tap_receipt/src/lib.rs
+++ b/tap_receipt/src/lib.rs
@@ -25,10 +25,10 @@ pub mod rav;
 mod received_receipt;
 pub mod state;
 
-use alloy::sol_types::SolStruct;
 pub use error::ReceiptError;
 pub use received_receipt::ReceiptWithState;
 use tap_eip712_message::{Eip712SignedMessage, SignatureBytes, SignatureBytesExt};
+use thegraph_core::alloy::sol_types::SolStruct;
 
 /// Result type for receipt
 pub type ReceiptResult<T> = Result<T, ReceiptError>;

--- a/tap_receipt/src/rav.rs
+++ b/tap_receipt/src/rav.rs
@@ -3,8 +3,8 @@
 
 //! Aggregation of Receipts
 
-use alloy::sol_types::SolStruct;
 use tap_eip712_message::Eip712SignedMessage;
+use thegraph_core::alloy::sol_types::SolStruct;
 
 use crate::{state::Checked, ReceiptWithState};
 


### PR DESCRIPTION
This pull request includes several changes to replace the `alloy` dependency with `thegraph-core` across multiple files. The changes primarily involve updating import statements and modifying references to the `alloy` library.

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R27): Added `thegraph-core` dependency and removed `alloy` dependency. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R27) [[2]](diffhunk://#diff-420656034c5073cf0f07190ef95e213b01c7c830015727db11367ec48f6ced28L11-R26)
* [`tap_aggregator/Cargo.toml`](diffhunk://#diff-f5f3437dbbff255b1d2694e10444cf2463f9ae5238c331508244fb673c176648R37): Updated dependencies to use `thegraph-core` with relevant features.

Note that `thegraph-core` v0.12.0 re-exports `alloy`'s version 0.12

