### PR TITLE
ci: add libsasl2-dev dependency to CI workflow

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -11,13 +11,10 @@ on:
           published, it will do nothing.
         required: false
         default: false
-
 permissions:
   contents: write
   pull-requests: write
-
 name: release-please
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -36,7 +33,6 @@ jobs:
         with:
           command: manifest
           token: ${{ steps.generate_token.outputs.token }}
-
   publish-crates:
     runs-on: ubuntu-latest
     # run only if release-please had released a new version
@@ -46,8 +42,8 @@ jobs:
     if: needs.release-please.outputs.releases_created == 'true' || github.event.inputs.force_publish == 'true'
     steps:
       - uses: actions/checkout@v3
-      - name: Install protobuf compiler
-        run: apt-get update && apt-get install protobuf-compiler -y
+      - name: Install system dependencies
+        run: apt-get update && apt-get install -y protobuf-compiler libsasl2-dev
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           command: manifest
           token: ${{ steps.generate_token.outputs.token }}
+          release-type: rust
   publish-crates:
     runs-on: ubuntu-latest
     # run only if release-please had released a new version


### PR DESCRIPTION
My intention is that this fixes our [release issue in CI](https://github.com/semiotic-ai/timeline-aggregation-protocol/actions/runs/14046408837/job/39328084893) so that we can release a crate using `thegraph-core` alloy dependencies. This in turn will allow us to tidy up in that area on indexer-rs.