### PR TITLE
build: centralize dependency imports in workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,38 @@ license = "Apache-2.0"
 repository = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
 
 [workspace.dependencies]
-serde = { version = "1.0.217", features = ["derive"] }
-rstest = "0.24.0"
 anyhow = { version = "1.0.95" }
-tokio = { version = "1.43.0", features = ["macros", "signal"] }
-rand = "0.8.5"
+anymap3 = "1.0.1"
+async-trait = "0.1.85"
+axum = { version = "0.7.5", features = [
+    "http1",
+    "json",
+    "matched-path",
+    "original-uri",
+    "query",
+    "tokio",
+], default-features = false }
+clap = { version = "4.5.15", features = ["derive", "env"] }
+criterion = { version = "0.5.1", features = ["async_std"] }
+futures-util = "0.3.28"
+hyper = { version = "1", features = ["full"] }
 jsonrpsee = { version = "0.24.7", features = ["macros", "server"] }
+jsonrpsee-core = "0.24.7"
+lazy_static = "1.4.0"
+log = "0.4.19"
+prometheus = "0.13.3"
+prost = "0.13.3"
+rayon = "1.10.0"
+rdkafka = { version = "0.37.0", features = ["tokio", "sasl"] }
+serde = { version = "1.0.217", features = ["derive"] }
+strum = { version = "0.26.3", features = ["derive"] }
+rstest = "0.24.0"
+tap_graph = { version = "0.2.1", path = "../tap_graph", features = ["v2"] }
+tokio = { version = "1.43.0", features = ["macros", "signal"] }
+tonic = { version = "0.12.3", features = ["transport", "zstd"] }
+tower = { version = "0.5.2", features = ["util", "steer"] }
+tracing-subscriber = "0.3.17"
+rand = "0.8.5"
 insta = { version = "1.42.0", features = ["json"] }
 serde_json = { version = "1.0.137", features = ["raw_value"] }
 thegraph-core = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [workspace]
 resolver = "2"
 members = [
-    "tap_core",
     "tap_aggregator",
-    "tap_integration_tests",
-    "tap_graph",
+    "tap_core",
     "tap_eip712_message",
+    "tap_graph",
+    "tap_integration_tests",
     "tap_receipt",
 ]
 
@@ -38,6 +38,7 @@ lazy_static = "1.5.0"
 log = "0.4.27"
 prometheus = "0.14.0"
 prost = "0.13.5"
+rand = "0.9.1"
 rayon = "1.10.0"
 rdkafka = { version = "0.37.0", features = ["tokio", "sasl"] }
 serde = { version = "1.0.219", features = ["derive"] }
@@ -51,4 +52,3 @@ tokio = { version = "1.44.2", features = ["macros", "signal"] }
 tonic = { version = "0.12.3", features = ["transport", "zstd"] }
 tower = { version = "0.5.2", features = ["util", "steer"] }
 tracing-subscriber = "0.3.19"
-rand = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ license = "Apache-2.0"
 repository = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
 
 [workspace.dependencies]
-anyhow = { version = "1.0.95" }
+anyhow = { version = "1.0.98" }
 anymap3 = "1.0.1"
-async-trait = "0.1.85"
+async-trait = "0.1.88"
 axum = { version = "0.7.5", features = [
     "http1",
     "json",
@@ -27,28 +27,28 @@ axum = { version = "0.7.5", features = [
     "query",
     "tokio",
 ], default-features = false }
-clap = { version = "4.5.15", features = ["derive", "env"] }
+clap = { version = "4.5.36", features = ["derive", "env"] }
 criterion = { version = "0.5.1", features = ["async_std"] }
-futures-util = "0.3.28"
-hyper = { version = "1", features = ["full"] }
-jsonrpsee = { version = "0.24.7", features = ["macros", "server"] }
-jsonrpsee-core = "0.24.7"
-lazy_static = "1.4.0"
-log = "0.4.19"
-prometheus = "0.13.3"
-prost = "0.13.3"
+futures-util = "0.3.31"
+hyper = { version = "1.6.0", features = ["full"] }
+insta = { version = "1.42.2", features = ["json"] }
+jsonrpsee = { version = "0.24.9", features = ["macros", "server"] }
+jsonrpsee-core = "0.24.9"
+lazy_static = "1.5.0"
+log = "0.4.27"
+prometheus = "0.14.0"
+prost = "0.13.5"
 rayon = "1.10.0"
 rdkafka = { version = "0.37.0", features = ["tokio", "sasl"] }
-serde = { version = "1.0.217", features = ["derive"] }
-strum = { version = "0.26.3", features = ["derive"] }
-rstest = "0.24.0"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = { version = "1.0.140", features = ["raw_value"] }
+strum = { version = "0.27.1", features = ["derive"] }
+rstest = "0.25.0"
 tap_graph = { version = "0.2.1", path = "../tap_graph", features = ["v2"] }
-tokio = { version = "1.43.0", features = ["macros", "signal"] }
+thegraph-core = "0.12.0"
+thiserror = "2.0.12"
+tokio = { version = "1.44.2", features = ["macros", "signal"] }
 tonic = { version = "0.12.3", features = ["transport", "zstd"] }
 tower = { version = "0.5.2", features = ["util", "steer"] }
-tracing-subscriber = "0.3.17"
-rand = "0.8.5"
-insta = { version = "1.42.0", features = ["json"] }
-serde_json = { version = "1.0.137", features = ["raw_value"] }
-thegraph-core = "0.12.0"
-thiserror = "2.0.11"
+tracing-subscriber = "0.3.19"
+rand = "0.9.1"

--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -23,17 +23,17 @@ log.workspace = true
 prometheus.workspace = true
 prost.workspace = true
 rayon.workspace = true
+rdkafka.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 tap_core = { path = "../tap_core", version = "4.0.0" }
+tap_graph = { version = "0.2.1", path = "../tap_graph", features = ["v2"] }
 thegraph-core = { workspace = true, features = ["alloy-eip712"] }
 tokio.workspace = true
 tonic.workspace = true
 tower.workspace = true
 tracing-subscriber.workspace = true
-tap_graph = { version = "0.2.1", path = "../tap_graph", features = ["v2"] }
-rdkafka.workspace = true        
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -13,39 +13,31 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
-axum = { version = "0.7.5", features = [
-    "http1",
-    "json",
-    "matched-path",
-    "original-uri",
-    "query",
-    "tokio",
-], default-features = false }
-clap = { version = "4.5.15", features = ["derive", "env"] }
-futures-util = "0.3.28"
-hyper = { version = "1", features = ["full"] }
-jsonrpsee = { workspace = true, features = ["server", "macros"] }
-lazy_static = "1.4.0"
-log = "0.4.19"
-prometheus = "0.13.3"
-prost = "0.13.3"
-rayon = "1.10.0"
+axum.workspace = true
+clap.workspace = true
+futures-util.workspace = true
+hyper.workspace = true
+jsonrpsee.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+prometheus.workspace = true
+prost.workspace = true
+rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-strum = { version = "0.26.3", features = ["derive"] }
+strum.workspace = true
 tap_core = { path = "../tap_core", version = "4.0.0" }
 thegraph-core = { workspace = true, features = ["alloy-eip712"] }
 tokio.workspace = true
-tonic = { version = "0.12.3", features = ["transport", "zstd"] }
-tower = { version = "0.5.2", features = ["util", "steer"] }
-tracing-subscriber = "0.3.17"
+tonic.workspace = true
+tower.workspace = true
+tracing-subscriber.workspace = true
 tap_graph = { version = "0.2.1", path = "../tap_graph", features = ["v2"] }
-rdkafka = { version = "0.37.0", features = ["tokio", "sasl"] }
+rdkafka.workspace = true        
 
 [build-dependencies]
 tonic-build = "0.12.3"
 
 [dev-dependencies]
-jsonrpsee = { workspace = true, features = ["http-client", "jsonrpsee-core"] }
 rand.workspace = true
 rstest.workspace = true

--- a/tap_aggregator/src/server.rs
+++ b/tap_aggregator/src/server.rs
@@ -496,7 +496,6 @@ mod tests {
     use std::{collections::HashSet, str::FromStr};
 
     use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
-    use rand::{prelude::*, seq::SliceRandom};
     use rstest::*;
     use tap_core::{signed_message::Eip712SignedMessage, tap_eip712_domain};
     use tap_graph::{Receipt, ReceiptAggregateVoucher};
@@ -600,6 +599,8 @@ mod tests {
         #[values(0, 1, 2)] random_seed: u64,
     ) {
         // The keys that will be used to sign the new RAVs
+
+        use rand::{rngs::StdRng, seq::IndexedRandom, SeedableRng};
         let keys_main = keys();
         // Extra keys to test the server's ability to accept multiple signers as input
         let keys_0 = keys();
@@ -681,6 +682,8 @@ mod tests {
         #[values(0, 1, 2, 3, 4)] random_seed: u64,
     ) {
         // The keys that will be used to sign the new RAVs
+
+        use rand::{rngs::StdRng, seq::IndexedRandom, SeedableRng};
         let keys_main = keys();
         // Extra keys to test the server's ability to accept multiple signers as input
         let keys_0 = keys();

--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Timeline Aggregation Protocol library: a fast, efficient and
 
 [dependencies]
 anyhow.workspace = true
-async-trait = "0.1.85"
+async-trait.workspace = true
 rand.workspace = true
 tap_eip712_message = { version = "0.1.0", path = "../tap_eip712_message" }
 tap_graph = { version = "0.2.1", path = "../tap_graph", optional = true }
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-criterion = { version = "0.5.1", features = ["async_std"] }
+criterion.workspace = true
 insta.workspace = true
 rstest.workspace = true
 serde_json.workspace = true

--- a/tap_core/tests/receipt_test.rs
+++ b/tap_core/tests/receipt_test.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use rand::{seq::SliceRandom, thread_rng};
+use rand::{rng, seq::SliceRandom};
 use rstest::*;
 use tap_core::{
     manager::{adapters::ReceiptStore, context::memory::InMemoryContext},
@@ -184,7 +184,7 @@ fn safe_truncate_receipts_test(
     let mut receipts_truncated = receipts_orig;
 
     // shuffle the input receipts
-    receipts_truncated.shuffle(&mut thread_rng());
+    receipts_truncated.shuffle(&mut rng());
 
     tap_core::manager::adapters::safe_truncate_receipts(&mut receipts_truncated, limit);
 

--- a/tap_graph/src/v1/receipt.rs
+++ b/tap_graph/src/v1/receipt.rs
@@ -10,7 +10,7 @@
 
 use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use serde::{Deserialize, Serialize};
 use tap_eip712_message::Eip712SignedMessage;
 use tap_receipt::WithValueAndTimestamp;
@@ -42,7 +42,7 @@ impl Receipt {
     /// Returns a receipt with provided values
     pub fn new(allocation_id: Address, value: u128) -> Result<Self, SystemTimeError> {
         let timestamp_ns = get_current_timestamp_u64_ns()?;
-        let nonce = thread_rng().gen::<u64>();
+        let nonce = rng().random::<u64>();
         Ok(Self {
             allocation_id,
             timestamp_ns,

--- a/tap_graph/src/v2/receipt.rs
+++ b/tap_graph/src/v2/receipt.rs
@@ -5,7 +5,7 @@
 
 use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use serde::{Deserialize, Serialize};
 use tap_eip712_message::Eip712SignedMessage;
 use tap_receipt::WithValueAndTimestamp;
@@ -50,7 +50,7 @@ impl Receipt {
         value: u128,
     ) -> Result<Self, SystemTimeError> {
         let timestamp_ns = get_current_timestamp_u64_ns()?;
-        let nonce = thread_rng().gen::<u64>();
+        let nonce = rng().random::<u64>();
         Ok(Self {
             allocation_id,
             payer,

--- a/tap_integration_tests/Cargo.toml
+++ b/tap_integration_tests/Cargo.toml
@@ -16,7 +16,7 @@ anyhow.workspace = true
 thegraph-core.workspace = true
 tokio.workspace = true
 jsonrpsee = { workspace = true, features = ["jsonrpsee-http-client"] }
-jsonrpsee-core = "0.24.7"
+jsonrpsee-core.workspace = true
 tap_graph = { path = "../tap_graph" }
 
 [dev-dependencies]

--- a/tap_integration_tests/Cargo.toml
+++ b/tap_integration_tests/Cargo.toml
@@ -11,13 +11,14 @@ publish = false
 [dependencies]
 tap_aggregator = { path = "../tap_aggregator" }
 tap_core = { path = "../tap_core", version = "4.0.0" }
-rand.workspace = true
+tap_graph = { path = "../tap_graph" }
+
 anyhow.workspace = true
-thegraph-core.workspace = true
-tokio.workspace = true
 jsonrpsee = { workspace = true, features = ["jsonrpsee-http-client"] }
 jsonrpsee-core.workspace = true
-tap_graph = { path = "../tap_graph" }
+rand.workspace = true
+thegraph-core.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -133,7 +133,7 @@ fn query_price() -> &'static [u128] {
     let mut v = Vec::new();
 
     for _ in 0..num_queries() {
-        v.push(rng.gen::<u128>() % 100);
+        v.push(rng.random::<u128>() % 100);
     }
     Box::leak(v.into_boxed_slice())
 }

--- a/tap_receipt/Cargo.toml
+++ b/tap_receipt/Cargo.toml
@@ -8,8 +8,8 @@ description = "TAP Receipt states and checks"
 
 [dependencies]
 anyhow.workspace = true
-anymap3 = "1.0.1"
-async-trait = "0.1.85"
+anymap3.workspace = true
+async-trait.workspace = true
 serde.workspace = true
 tap_eip712_message = { version = "0.1.0", path = "../tap_eip712_message" }
 thegraph-core.workspace = true


### PR DESCRIPTION
Using the workspace manifest where plausible, updating to latest where it's simple.