### PR TITLE
build: update thegraph-core (alloy) to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = { version = "1.0.140", features = ["raw_value"] }
 strum = { version = "0.27.1", features = ["derive"] }
 rstest = "0.25.0"
 tap_graph = { version = "0.2.1", path = "../tap_graph", features = ["v2"] }
-thegraph-core = "0.12.0"
+thegraph-core = "0.14.0"
 thiserror = "2.0.12"
 tokio = { version = "1.44.2", features = ["macros", "signal"] }
 tonic = { version = "0.13.0", features = ["transport", "zstd"] }

--- a/tap_core/tests/rav_test.rs
+++ b/tap_core/tests/rav_test.rs
@@ -19,7 +19,7 @@ use tap_core::{
 };
 use tap_graph::{Receipt, ReceiptAggregateVoucher};
 #[allow(deprecated)]
-use thegraph_core::alloy::primitives::{Address, PrimitiveSignature, Signature};
+use thegraph_core::alloy::primitives::{Address, Signature};
 use thegraph_core::alloy::{
     dyn_abi::Eip712Domain,
     signers::local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner},
@@ -85,7 +85,7 @@ fn check_for_rav_serialization(domain_separator: Eip712Domain) {
       "yParity": "0x1"
     }"#;
 
-    serde_json::from_str::<PrimitiveSignature>(raw_sig).unwrap();
+    serde_json::from_str::<Signature>(raw_sig).unwrap();
     #[allow(deprecated)]
     serde_json::from_str::<Signature>(raw_sig).unwrap();
 }

--- a/tap_core/tests/receipt_test.rs
+++ b/tap_core/tests/receipt_test.rs
@@ -7,7 +7,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use rand::{rng, seq::SliceRandom};
 use rstest::*;
 use tap_core::{
     manager::{adapters::ReceiptStore, context::memory::InMemoryContext},
@@ -159,6 +158,8 @@ fn safe_truncate_receipts_test(
     #[case] limit: u64,
     #[case] expected: Vec<u64>,
 ) {
+    use rand::{rng, seq::SliceRandom};
+
     let wallet = PrivateKeySigner::random();
 
     // Vec of (id, receipt)

--- a/tap_eip712_message/src/lib.rs
+++ b/tap_eip712_message/src/lib.rs
@@ -25,7 +25,7 @@
 use serde::{Deserialize, Serialize};
 use thegraph_core::alloy::{
     dyn_abi::Eip712Domain,
-    primitives::{Address, PrimitiveSignature as Signature},
+    primitives::{Address, Signature},
     signers::{local::PrivateKeySigner, SignerSync},
     sol_types::SolStruct,
 };


### PR DESCRIPTION
We need to update our alloy dependencies here in order to update them when we upgrade TAP as a dependency of indexer-rs.