### PR TITLE
build: update axum to latest along with tonic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
 anyhow = { version = "1.0.98" }
 anymap3 = "1.0.1"
 async-trait = "0.1.88"
-axum = { version = "0.7.5", features = [
+axum = { version = "0.8.3", features = [
     "http1",
     "json",
     "matched-path",
@@ -49,6 +49,6 @@ tap_graph = { version = "0.2.1", path = "../tap_graph", features = ["v2"] }
 thegraph-core = "0.12.0"
 thiserror = "2.0.12"
 tokio = { version = "1.44.2", features = ["macros", "signal"] }
-tonic = { version = "0.12.3", features = ["transport", "zstd"] }
+tonic = { version = "0.13.0", features = ["transport", "zstd"] }
 tower = { version = "0.5.2", features = ["util", "steer"] }
 tracing-subscriber = "0.3.19"

--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -36,7 +36,7 @@ tower.workspace = true
 tracing-subscriber.workspace = true
 
 [build-dependencies]
-tonic-build = "0.12.3"
+tonic-build = "0.13.0"
 
 [dev-dependencies]
 rand.workspace = true


### PR DESCRIPTION
This will allow us to update axum where tap aggregator is used, such as indexer-rs. See, for example [https://github.com/graphprotocol/indexer-rs/pull/699](https://github.com/graphprotocol/indexer-rs/pull/699).