### PR TITLE
fix: improve receipt deduplication with signature normalization

### DIFF
--- a/tap_core/src/manager/tap_manager.rs
+++ b/tap_core/src/manager/tap_manager.rs
@@ -138,12 +138,13 @@ where
         let mut failed_receipts = vec![];
 
         // check for timestamp
-        let (checking_receipts, already_failed) =
-            TimestampCheck(min_timestamp_ns).check_batch(checking_receipts);
+        let (checking_receipts, already_failed) = TimestampCheck(min_timestamp_ns)
+            .check_batch(&self.domain_separator, checking_receipts)?;
         failed_receipts.extend(already_failed);
 
         // check for uniqueness
-        let (checking_receipts, already_failed) = UniqueCheck.check_batch(checking_receipts);
+        let (checking_receipts, already_failed) =
+            UniqueCheck.check_batch(&self.domain_separator, checking_receipts)?;
         failed_receipts.extend(already_failed);
 
         for receipt in checking_receipts.into_iter() {

--- a/tap_core/tests/manager_test.rs
+++ b/tap_core/tests/manager_test.rs
@@ -139,7 +139,7 @@ async fn manager_verify_and_store_varying_initial_checks(
         &signer,
     )
     .unwrap();
-    let query_id = signed_receipt.unique_hash();
+    let query_id = signed_receipt.unique_hash(&domain_separator).unwrap();
     query_appraisals.write().unwrap().insert(query_id, value);
     escrow_storage
         .write()
@@ -182,7 +182,7 @@ async fn manager_create_rav_request_all_valid_receipts(
             &signer,
         )
         .unwrap();
-        let query_id = signed_receipt.unique_hash();
+        let query_id = signed_receipt.unique_hash(&domain_separator).unwrap();
         stored_signed_receipts.push(signed_receipt.clone());
         query_appraisals.write().unwrap().insert(query_id, value);
         assert!(manager
@@ -277,7 +277,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts(
             &signer,
         )
         .unwrap();
-        let query_id = signed_receipt.unique_hash();
+        let query_id = signed_receipt.unique_hash(&domain_separator).unwrap();
         stored_signed_receipts.push(signed_receipt.clone());
         query_appraisals.write().unwrap().insert(query_id, value);
         assert!(manager
@@ -321,7 +321,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts(
         )
         .unwrap();
 
-        let query_id = signed_receipt.unique_hash();
+        let query_id = signed_receipt.unique_hash(&domain_separator).unwrap();
         stored_signed_receipts.push(signed_receipt.clone());
         query_appraisals.write().unwrap().insert(query_id, value);
         assert!(manager
@@ -389,7 +389,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
         receipt.timestamp_ns = starting_min_timestamp + query_id + 1;
         let signed_receipt = Eip712SignedMessage::new(&domain_separator, receipt, &signer).unwrap();
 
-        let query_id = signed_receipt.unique_hash();
+        let query_id = signed_receipt.unique_hash(&domain_separator).unwrap();
         stored_signed_receipts.push(signed_receipt.clone());
         query_appraisals.write().unwrap().insert(query_id, value);
         assert!(manager
@@ -436,7 +436,7 @@ async fn manager_create_multiple_rav_requests_all_valid_receipts_consecutive_tim
         let mut receipt = Receipt::new(allocation_ids[0], value).unwrap();
         receipt.timestamp_ns = starting_min_timestamp + query_id + 1;
         let signed_receipt = Eip712SignedMessage::new(&domain_separator, receipt, &signer).unwrap();
-        let query_id = signed_receipt.unique_hash();
+        let query_id = signed_receipt.unique_hash(&domain_separator).unwrap();
         stored_signed_receipts.push(signed_receipt.clone());
         query_appraisals.write().unwrap().insert(query_id, value);
         assert!(manager

--- a/tap_core/tests/received_receipt_test.rs
+++ b/tap_core/tests/received_receipt_test.rs
@@ -113,7 +113,7 @@ async fn partial_then_full_check_valid_receipt(
     )
     .unwrap();
 
-    let query_id = signed_receipt.unique_hash();
+    let query_id = signed_receipt.unique_hash(&domain_separator).unwrap();
 
     // add escrow for sender
     escrow_storage
@@ -156,7 +156,7 @@ async fn partial_then_finalize_valid_receipt(
         &signer,
     )
     .unwrap();
-    let query_id = signed_receipt.unique_hash();
+    let query_id = signed_receipt.unique_hash(&domain_separator).unwrap();
 
     // add escrow for sender
     escrow_storage
@@ -203,7 +203,7 @@ async fn standard_lifetime_valid_receipt(
     )
     .unwrap();
 
-    let query_id = signed_receipt.unique_hash();
+    let query_id = signed_receipt.unique_hash(&domain_separator).unwrap();
 
     // add escrow for sender
     escrow_storage

--- a/tap_eip712_message/src/lib.rs
+++ b/tap_eip712_message/src/lib.rs
@@ -25,7 +25,7 @@
 use serde::{Deserialize, Serialize};
 use thegraph_core::alloy::{
     dyn_abi::Eip712Domain,
-    primitives::{Address, Signature},
+    primitives::{keccak256, Address, Signature},
     signers::{local::PrivateKeySigner, SignerSync},
     sol_types::SolStruct,
 };
@@ -105,8 +105,21 @@ impl<M: SolStruct> Eip712SignedMessage<M> {
         Ok(recovered_address)
     }
 
-    /// Use this as a simple key for testing
-    pub fn unique_hash(&self) -> MessageId {
-        MessageId(self.message.eip712_hash_struct().into())
+    /// Generate a uniqueness identifier using both the message content and the recovered signer
+    pub fn unique_hash(&self, domain_separator: &Eip712Domain) -> Result<MessageId, Eip712Error> {
+        // Get the hash of just the message content
+        let message_hash = self.message.eip712_hash_struct();
+
+        // Recover the signer address
+        let signer = self.recover_signer(domain_separator)?;
+
+        // Create a new hash combining both the message hash and the signer address
+        let mut input = Vec::with_capacity(32 + 20); // 32 bytes for hash, 20 bytes for address
+        input.extend_from_slice(&message_hash.0);
+        input.extend_from_slice(signer.as_ref());
+
+        let combined_hash = keccak256(&input);
+
+        Ok(MessageId(*combined_hash))
     }
 }

--- a/tap_receipt/src/lib.rs
+++ b/tap_receipt/src/lib.rs
@@ -27,8 +27,8 @@ pub mod state;
 
 pub use error::ReceiptError;
 pub use received_receipt::ReceiptWithState;
-use tap_eip712_message::{Eip712SignedMessage, SignatureBytes, SignatureBytesExt};
-use thegraph_core::alloy::sol_types::SolStruct;
+use tap_eip712_message::{Eip712Error, Eip712SignedMessage, MessageId};
+use thegraph_core::alloy::{dyn_abi::Eip712Domain, sol_types::SolStruct};
 
 /// Result type for receipt
 pub type ReceiptResult<T> = Result<T, ReceiptError>;
@@ -45,7 +45,7 @@ pub trait WithValueAndTimestamp {
 /// Extension that allows UniqueCheck for any SolStruct receipt
 pub trait WithUniqueId {
     type Output: Eq + std::hash::Hash;
-    fn unique_id(&self) -> Self::Output;
+    fn unique_id(&self, domain_separator: &Eip712Domain) -> Result<Self::Output, Eip712Error>;
 }
 
 impl<T> WithValueAndTimestamp for Eip712SignedMessage<T>
@@ -65,9 +65,9 @@ impl<T> WithUniqueId for Eip712SignedMessage<T>
 where
     T: SolStruct,
 {
-    type Output = SignatureBytes;
+    type Output = MessageId;
 
-    fn unique_id(&self) -> Self::Output {
-        self.signature.get_signature_bytes()
+    fn unique_id(&self, domain_separator: &Eip712Domain) -> Result<Self::Output, Eip712Error> {
+        self.unique_hash(domain_separator)
     }
 }


### PR DESCRIPTION
# Description

This PR improves the security of receipt deduplication by making it resistant to signature malleability attacks. The implementation now identifies receipts based on their message content and recovered signer, rather than just raw signature bytes.

## Changes

- Replaced `unique_hash` method to `Eip712SignedMessage` that combines message content and signer address
- Updated `check_signatures_unique` to use this malleation-resistant approach
- Added test case demonstrating the signature malleability issue and verifying the fix

