### PR TITLE
fix(Cargo.toml): bump workspace crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,11 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["raw_value"] }
 strum = { version = "0.27.1", features = ["derive"] }
 rstest = "0.25.0"
-tap_aggregator = { version = "0.5.2", path = "tap_aggregator" }
+tap_aggregator = { version = "0.5.3", path = "tap_aggregator" }
 tap_eip712_message = { version = "0.2.1", path = "tap_eip712_message" }
-tap_core = { version = "4.1.1", path = "tap_core" }
-tap_graph = { version = "0.3.1", path = "tap_graph", features = ["v2"] }
-tap_receipt = { version = "1.1.1", path = "tap_receipt" }
+tap_core = { version = "4.1.2", path = "tap_core" }
+tap_graph = { version = "0.3.2", path = "tap_graph", features = ["v2"] }
+tap_receipt = { version = "1.1.2", path = "tap_receipt" }
 thegraph-core = "0.15.0"
 thiserror = "2.0.12"
 tokio = { version = "1.44.2", features = ["macros", "signal"] }


### PR DESCRIPTION
This just keeps the crate versions for crates from this workspace that we're importing at the latest versions.