### PR TITLE
fix: clean target directory in ci release workflow

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -45,17 +45,19 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install system dependencies
         run: apt-get update && apt-get install -y protobuf-compiler libsasl2-dev
+      - name: Clean target directory
+        run: rm -rf target
       - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces
       - name: Publish workspace crates
         # `--no-remove-dev-deps` is a workaround for https://github.com/pksunkara/cargo-workspaces/issues/103
-        run: cargo workspaces publish --from-git --no-remove-dev-deps -y
+        run: |
+          cargo workspaces publish --from-git --no-remove-dev-deps -y
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Still out on a limb seeing if the issue [here](https://github.com/semiotic-ai/timeline-aggregation-protocol/actions/runs/15174930398/job/42673246346) is something we can fix without assuming it's a cargo workspace issue.