### PR TITLE
fix: update tap aggregator version

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -45,19 +45,17 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install system dependencies
         run: apt-get update && apt-get install -y protobuf-compiler libsasl2-dev
-      - name: Clean target directory
-        run: rm -rf target
       - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces
       - name: Publish workspace crates
         # `--no-remove-dev-deps` is a workaround for https://github.com/pksunkara/cargo-workspaces/issues/103
-        run: |
-          cargo workspaces publish --from-git --no-remove-dev-deps -y
+        run: cargo workspaces publish --from-git --no-remove-dev-deps -y
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["raw_value"] }
 strum = { version = "0.27.1", features = ["derive"] }
 rstest = "0.25.0"
-tap_aggregator = { version = "0.5.3", path = "tap_aggregator" }
+tap_aggregator = { version = "0.5.4", path = "tap_aggregator" }
 tap_eip712_message = { version = "0.2.1", path = "tap_eip712_message" }
 tap_core = { version = "4.1.2", path = "tap_core" }
 tap_graph = { version = "0.3.2", path = "tap_graph", features = ["v2"] }


### PR DESCRIPTION
We were not using the most recent `tap_aggregator` crate version in our workspace manifest and this would make sense as a reason for our [release-please CI pipeline failures](https://github.com/semiotic-ai/timeline-aggregation-protocol/actions/runs/15174930398/job/42673246346).

Since a previously attempted fix did not help this PR also reverts [that change](https://github.com/semiotic-ai/timeline-aggregation-protocol/pull/304/commits/8e39ceb4cfa66c179d7410ff7e1008211bef7cfc).

