### PR TITLE
fix(tap_core): remove need to allow deprecated APIs

### DIFF
--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -14,7 +14,7 @@ rand.workspace = true
 tap_eip712_message.workspace = true
 tap_graph = { workspace = true, optional = true }
 tap_receipt.workspace = true
-thegraph-core.workspace = true
+thegraph-core = { workspace = true, features = ["alloy-signer-mnemonic"] }
 thiserror.workspace = true
 tokio.workspace = true
 

--- a/tap_core/tests/rav_test.rs
+++ b/tap_core/tests/rav_test.rs
@@ -18,10 +18,9 @@ use tap_core::{
     tap_eip712_domain,
 };
 use tap_graph::{Receipt, ReceiptAggregateVoucher};
-#[allow(deprecated)]
-use thegraph_core::alloy::primitives::{Address, Signature};
 use thegraph_core::alloy::{
     dyn_abi::Eip712Domain,
+    primitives::{Address, Signature},
     signers::local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner},
 };
 
@@ -86,8 +85,6 @@ fn check_for_rav_serialization(domain_separator: Eip712Domain) {
     }"#;
 
     serde_json::from_str::<Signature>(raw_sig).unwrap();
-    #[allow(deprecated)]
-    serde_json::from_str::<Signature>(raw_sig).unwrap();
 }
 
 #[rstest]
@@ -119,7 +116,7 @@ async fn rav_storage_adapter_test(domain_separator: Eip712Domain, context: InMem
 
     context.update_last_rav(signed_rav.clone()).await.unwrap();
 
-    // Retreive rav
+    // Retrieve rav
     let retrieved_rav = context.last_rav().await;
     assert!(retrieved_rav.unwrap().unwrap() == signed_rav);
 
@@ -148,7 +145,7 @@ async fn rav_storage_adapter_test(domain_separator: Eip712Domain, context: InMem
     // Update the last rav
     context.update_last_rav(signed_rav.clone()).await.unwrap();
 
-    // Retreive rav
+    // Retrieve rav
     let retrieved_rav = context.last_rav().await;
     assert!(retrieved_rav.unwrap().unwrap() == signed_rav);
 }


### PR DESCRIPTION
Still trying eliminate causes of the co-present and conflicting `alloy-signer-local` versions.