### PR TITLE
fix(eip712-message): canonicalize to low-S before returning bytes

### DIFF
--- a/tap_eip712_message/src/lib.rs
+++ b/tap_eip712_message/src/lib.rs
@@ -62,7 +62,9 @@ pub trait SignatureBytesExt {
 
 impl SignatureBytesExt for Signature {
     fn get_signature_bytes(&self) -> SignatureBytes {
-        SignatureBytes(self.as_bytes())
+        // Canonicalize to low-S form before returning bytes
+        let canonical = self.normalized_s();
+        SignatureBytes(canonical.as_bytes())
     }
 }
 

--- a/tap_receipt/src/lib.rs
+++ b/tap_receipt/src/lib.rs
@@ -68,6 +68,6 @@ where
     type Output = SignatureBytes;
 
     fn unique_id(&self) -> Self::Output {
-        self.signature.normalized_s().get_signature_bytes()
+        self.signature.get_signature_bytes()
     }
 }


### PR DESCRIPTION
[Clickup](https://app.clickup.com/t/9011608233/TASK-803)

