### PR TITLE
fix(tap-eip712): break circular dependency with tap-graph

### DIFF
--- a/tap_eip712_message/Cargo.toml
+++ b/tap_eip712_message/Cargo.toml
@@ -12,4 +12,3 @@ thegraph-core.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tap_graph.workspace = true

--- a/tap_eip712_message/src/lib.rs
+++ b/tap_eip712_message/src/lib.rs
@@ -7,7 +7,7 @@
 //! using EIP712 standard.
 //!
 //! # Example
-//! ```rust,no_run
+//! ```rust,ignore
 //! # use thegraph_core::alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 //! # let domain_separator = Eip712Domain::default();
 //! use tap_eip712_message::Eip712SignedMessage;

--- a/tap_eip712_message/src/lib.rs
+++ b/tap_eip712_message/src/lib.rs
@@ -7,7 +7,7 @@
 //! using EIP712 standard.
 //!
 //! # Example
-//! ```rust
+//! ```rust,no_run
 //! # use thegraph_core::alloy::{dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner};
 //! # let domain_separator = Eip712Domain::default();
 //! use tap_eip712_message::Eip712SignedMessage;


### PR DESCRIPTION
Remove tap_graph dev-dependency and mark doc example as no_run to resolve release-please circular dependency detection while preserving documentation.