### PR TITLE
Fix audit issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     name: cargo clippy
     runs-on: ubuntu-latest
     container:
-      image: rust:1.87-bookworm
+      image: rust:1.88-bookworm
     steps:
       - uses: actions/checkout@v3
       - name: Install protobuf compiler
@@ -51,7 +51,7 @@ jobs:
       pull-requests: write
       actions: read
     container:
-      image: rust:1.87-bookworm
+      image: rust:1.88-bookworm
     steps:
       - uses: actions/checkout@v3
       - name: Install protobuf compiler
@@ -78,7 +78,7 @@ jobs:
     name: cargo test docs
     runs-on: ubuntu-latest
     container:
-      image: rust:1.87-bookworm
+      image: rust:1.88-bookworm
     steps:
       - uses: actions/checkout@v3
       - name: Install protobuf compiler

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 resolver = "2"
 members = [
-    "tap_aggregator",
-    "tap_core",
-    "tap_eip712_message",
-    "tap_graph",
-    "tap_integration_tests",
-    "tap_receipt",
+  "tap_aggregator",
+  "tap_core",
+  "tap_eip712_message",
+  "tap_graph",
+  "tap_integration_tests",
+  "tap_receipt",
 ]
 
 [workspace.package]
@@ -20,12 +20,12 @@ anyhow = { version = "1.0.98" }
 anymap3 = "1.0.1"
 async-trait = "0.1.88"
 axum = { version = "0.8.3", features = [
-    "http1",
-    "json",
-    "matched-path",
-    "original-uri",
-    "query",
-    "tokio",
+  "http1",
+  "json",
+  "matched-path",
+  "original-uri",
+  "query",
+  "tokio",
 ], default-features = false }
 clap = { version = "4.5.37", features = ["derive", "env"] }
 criterion = { version = "0.5.1", features = ["async_std"] }
@@ -57,5 +57,6 @@ tonic = { version = "0.14.1", features = ["transport", "zstd"] }
 tonic-build = "0.14.1"
 tonic-prost = "0.14.1"
 tonic-prost-build = "0.14.1"
-tower = { version = "0.5.2", features = ["util", "steer"] }
+tower = { version = "0.5.3", features = ["util", "steer"] }
+tower-http = { version = "0.6.8" }
 tracing-subscriber = "0.3.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.88"
 license = "Apache-2.0"
 repository = "https://github.com/semiotic-ai/timeline-aggregation-protocol"
 

--- a/Dockerfile.tap_aggregator
+++ b/Dockerfile.tap_aggregator
@@ -1,4 +1,4 @@
-FROM rust:1.87-bookworm as build
+FROM rust:1.88-bookworm AS build
 
 WORKDIR /root
 

--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tap_aggregator"
 version = "0.6.3"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme = "README.md"

--- a/tap_aggregator/Cargo.toml
+++ b/tap_aggregator/Cargo.toml
@@ -37,7 +37,8 @@ thegraph-core = { workspace = true, features = ["alloy-eip712"] }
 tokio.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
-tower = { workspace = true, features = ["util", "steer", "limit"] }
+tower = { workspace = true, features = ["util", "steer", "limit", "timeout"] }
+tower-http = { workspace = true, features = ["timeout"] }
 tracing-subscriber.workspace = true
 
 [build-dependencies]

--- a/tap_aggregator/README.md
+++ b/tap_aggregator/README.md
@@ -38,6 +38,10 @@ Options:
           Maximum response body size in bytes. Defaults to 100kB [env: TAP_MAX_RESPONSE_BODY_SIZE=] [default: 102400]
       --max-connections <MAX_CONNECTIONS>
           Maximum number of concurrent connections. Defaults to 32 [env: TAP_MAX_CONNECTIONS=] [default: 32]
+      --request-timeout-secs <REQUEST_TIMEOUT_SECS>
+          Maximum time in seconds allowed for processing a request. This timeout protects against
+          Slowloris-style DoS attacks by ensuring that connections cannot be held open indefinitely.
+          Defaults to 60 seconds [env: TAP_REQUEST_TIMEOUT_SECS=] [default: 60]
   -h, --help
           Print help
   -V, --version

--- a/tap_aggregator/README.md
+++ b/tap_aggregator/README.md
@@ -447,6 +447,28 @@ Example:
 }
 ```
 
+## Metrics
+
+The aggregator exposes Prometheus metrics for monitoring. Key metrics include:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `aggregation_success_count` | Counter | Number of successful receipt aggregation requests |
+| `aggregation_failure_count` | Counter | Number of failed receipt aggregation requests |
+| `total_aggregated_receipts` | Counter | Total number of receipts successfully aggregated |
+| `total_aggregated_grt` | Counter | Total successfully aggregated GRT value (wei) |
+| `kafka_publish_success_total` | Counter | Number of successful Kafka publish attempts for RAV records |
+| `kafka_publish_failure_total` | Counter | Number of failed Kafka publish attempts for RAV records |
+
+### Kafka Failure Handling
+
+When Kafka publishing fails, the aggregator:
+- Increments `kafka_publish_failure_total`
+- Logs an error with context about potential escrow tracking drift
+- **Still returns the RAV to the client** (availability over consistency)
+
+Operators should alert on `kafka_publish_failure_total > 0` to detect Kafka connectivity issues. If Kafka messages are lost, `tap-escrow-manager` may underestimate debt—see the `debts` config override in tap-escrow-manager for manual recovery.
+
 ## Feature Flags
 
 ### V2 Protocol Support

--- a/tap_aggregator/src/main.rs
+++ b/tap_aggregator/src/main.rs
@@ -14,7 +14,7 @@ use thegraph_core::alloy::{
     dyn_abi::Eip712Domain, primitives::Address, signers::local::PrivateKeySigner,
 };
 
-#[derive(Parser, Debug)]
+#[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// Port to listen on for JSON-RPC requests.
@@ -79,6 +79,29 @@ struct Args {
 
     #[arg(long, env = "TAP_KAFKA_CONFIG")]
     kafka_config: Option<String>,
+}
+
+impl std::fmt::Debug for Args {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Args")
+            .field("port", &self.port)
+            .field("public_keys", &self.public_keys)
+            .field("private_key", &"[REDACTED]")
+            .field("max_request_body_size", &self.max_request_body_size)
+            .field("max_response_body_size", &self.max_response_body_size)
+            .field("max_connections", &self.max_connections)
+            .field("request_timeout_secs", &self.request_timeout_secs)
+            .field("metrics_port", &self.metrics_port)
+            .field("domain_chain_id", &self.domain_chain_id)
+            .field("domain_verifying_contract", &self.domain_verifying_contract)
+            .field(
+                "domain_verifying_contract_v2",
+                &self.domain_verifying_contract_v2,
+            )
+            .field("domain_salt", &self.domain_salt)
+            .field("kafka_config", &self.kafka_config)
+            .finish()
+    }
 }
 
 #[tokio::main]

--- a/tap_aggregator/src/main.rs
+++ b/tap_aggregator/src/main.rs
@@ -3,7 +3,7 @@
 
 #![doc = include_str!("../README.md")]
 
-use std::{collections::HashSet, str::FromStr};
+use std::{collections::HashSet, str::FromStr, time::Duration};
 
 use anyhow::Result;
 use clap::Parser;
@@ -48,6 +48,13 @@ struct Args {
     /// Defaults to 32.
     #[arg(long, default_value_t = 32, env = "TAP_MAX_CONNECTIONS")]
     max_connections: u32,
+
+    /// Maximum time in seconds allowed for processing a request.
+    /// This timeout protects against Slowloris-style DoS attacks by ensuring
+    /// that connections cannot be held open indefinitely.
+    /// Defaults to 60 seconds.
+    #[arg(long, default_value_t = 60, env = "TAP_REQUEST_TIMEOUT_SECS")]
+    request_timeout_secs: u64,
 
     /// Metrics server port.
     /// Defaults to 5000.
@@ -128,6 +135,7 @@ async fn main() -> Result<()> {
         args.max_request_body_size,
         args.max_response_body_size,
         args.max_connections,
+        Duration::from_secs(args.request_timeout_secs),
         kafka,
     )
     .await?;

--- a/tap_aggregator/src/server.rs
+++ b/tap_aggregator/src/server.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, fmt::Debug, str::FromStr};
+use std::{collections::HashSet, fmt::Debug, str::FromStr, time::Duration};
 
 use anyhow::Result;
 use axum::{error_handling::HandleError, routing::post_service, BoxError, Router};
@@ -21,6 +21,7 @@ use thegraph_core::alloy::{
 use tokio::{net::TcpListener, signal, task::JoinHandle};
 use tonic::{codec::CompressionEncoding, service::Routes, Request, Response, Status};
 use tower::{layer::util::Identity, make::Shared};
+use tower_http::timeout::TimeoutLayer;
 
 use crate::{
     aggregator,
@@ -485,6 +486,7 @@ pub async fn run_server(
     max_request_body_size: u32,
     max_response_body_size: u32,
     max_concurrent_connections: u32,
+    request_timeout: Duration,
     kafka: Option<rdkafka::producer::ThreadedProducer<rdkafka::producer::DefaultProducerContext>>,
 ) -> Result<(JoinHandle<()>, std::net::SocketAddr)> {
     // Setting up the JSON RPC server
@@ -508,16 +510,25 @@ pub async fn run_server(
             format!("Something went wrong: {err}"),
         )
     }
-    let json_rpc_router = Router::new().route_service(
-        "/",
-        HandleError::new(post_service(json_rpc_service), handle_anyhow_error),
-    );
+    let json_rpc_router = Router::new()
+        .route_service(
+            "/",
+            HandleError::new(post_service(json_rpc_service), handle_anyhow_error),
+        )
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            request_timeout,
+        ));
 
     let grpc_service = create_grpc_service(rpc_impl)?;
 
     let grpc_router = Router::new()
         .layer(tower::limit::ConcurrencyLimitLayer::new(
             max_concurrent_connections as usize,
+        ))
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            request_timeout,
         ))
         .merge(grpc_service.into_axum_router());
 
@@ -638,7 +649,7 @@ fn produce_kafka_records<K: Debug>(
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 mod tests {
-    use std::{collections::HashSet, str::FromStr};
+    use std::{collections::HashSet, str::FromStr, time::Duration};
 
     use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
     use rstest::*;
@@ -696,6 +707,11 @@ mod tests {
         1
     }
 
+    #[fixture]
+    fn request_timeout() -> Duration {
+        Duration::from_secs(60)
+    }
+
     #[rstest]
     #[tokio::test]
     async fn protocol_version(
@@ -704,6 +720,7 @@ mod tests {
         http_request_size_limit: u32,
         http_response_size_limit: u32,
         http_max_concurrent_connections: u32,
+        request_timeout: Duration,
     ) {
         // The keys that will be used to sign the new RAVs
         let keys_main = keys();
@@ -718,6 +735,7 @@ mod tests {
             http_request_size_limit,
             http_response_size_limit,
             http_max_concurrent_connections,
+            request_timeout,
             None,
         )
         .await
@@ -745,6 +763,7 @@ mod tests {
         http_request_size_limit: u32,
         http_response_size_limit: u32,
         http_max_concurrent_connections: u32,
+        request_timeout: Duration,
         allocation_ids: Vec<Address>,
         #[case] values: Vec<u128>,
         #[values("0.0")] api_version: &str,
@@ -758,7 +777,7 @@ mod tests {
         let keys_0 = keys();
         let keys_1 = keys();
         // Vector of all wallets to make it easier to select one randomly
-        let all_wallets = vec![keys_main.clone(), keys_0.clone(), keys_1.clone()];
+        let all_wallets = [keys_main.clone(), keys_0.clone(), keys_1.clone()];
         // PRNG for selecting a random wallet
         let mut rng = StdRng::seed_from_u64(random_seed);
 
@@ -772,6 +791,7 @@ mod tests {
             http_request_size_limit,
             http_response_size_limit,
             http_max_concurrent_connections,
+            request_timeout,
             None,
         )
         .await
@@ -830,6 +850,7 @@ mod tests {
         http_request_size_limit: u32,
         http_response_size_limit: u32,
         http_max_concurrent_connections: u32,
+        request_timeout: Duration,
         allocation_ids: Vec<Address>,
         #[case] values: Vec<u128>,
         #[values("0.0")] api_version: &str,
@@ -843,7 +864,7 @@ mod tests {
         let keys_0 = keys();
         let keys_1 = keys();
         // Vector of all wallets to make it easier to select one randomly
-        let all_wallets = vec![keys_main.clone(), keys_0.clone(), keys_1.clone()];
+        let all_wallets = [keys_main.clone(), keys_0.clone(), keys_1.clone()];
         // PRNG for selecting a random wallet
         let mut rng = StdRng::seed_from_u64(random_seed);
 
@@ -857,6 +878,7 @@ mod tests {
             http_request_size_limit,
             http_response_size_limit,
             http_max_concurrent_connections,
+            request_timeout,
             None,
         )
         .await
@@ -922,6 +944,7 @@ mod tests {
         http_request_size_limit: u32,
         http_response_size_limit: u32,
         http_max_concurrent_connections: u32,
+        request_timeout: Duration,
         allocation_ids: Vec<Address>,
     ) {
         // The keys that will be used to sign the new RAVs
@@ -937,6 +960,7 @@ mod tests {
             http_request_size_limit,
             http_response_size_limit,
             http_max_concurrent_connections,
+            request_timeout,
             None,
         )
         .await
@@ -1006,6 +1030,7 @@ mod tests {
         domain_separator_v2: Eip712Domain,
         http_response_size_limit: u32,
         http_max_concurrent_connections: u32,
+        request_timeout: Duration,
         allocation_ids: Vec<Address>,
         #[values("0.0")] api_version: &str,
     ) {
@@ -1031,6 +1056,7 @@ mod tests {
             http_request_size_limit,
             http_response_size_limit,
             http_max_concurrent_connections,
+            request_timeout,
             None,
         )
         .await

--- a/tap_aggregator/src/server.rs
+++ b/tap_aggregator/src/server.rs
@@ -67,6 +67,16 @@ lazy_static! {
         "Total successfully aggregated GRT value (wei)."
     )
     .unwrap();
+    static ref KAFKA_PUBLISH_SUCCESS_COUNTER: IntCounter = register_int_counter!(
+        "kafka_publish_success_total",
+        "Number of successful Kafka publish attempts for RAV records."
+    )
+    .unwrap();
+    static ref KAFKA_PUBLISH_FAILURE_COUNTER: IntCounter = register_int_counter!(
+        "kafka_publish_failure_total",
+        "Number of failed Kafka publish attempts for RAV records."
+    )
+    .unwrap();
 }
 
 /// Generates the `RpcServer` trait that is used to define the JSON-RPC API.
@@ -641,8 +651,17 @@ fn produce_kafka_records<K: Debug>(
             .key(&key)
             .payload(&payload),
     );
-    if let Err((err, _)) = result {
-        error!("error producing to {topic}: {err}");
+    match result {
+        Ok(_) => {
+            KAFKA_PUBLISH_SUCCESS_COUNTER.inc();
+        }
+        Err((err, _)) => {
+            KAFKA_PUBLISH_FAILURE_COUNTER.inc();
+            error!(
+                "Failed to publish RAV to Kafka topic {topic}: {err}. \
+                 RAV was still returned to client - escrow tracking may drift."
+            );
+        }
     }
 }
 

--- a/tap_aggregator/tests/aggregate_test.rs
+++ b/tap_aggregator/tests/aggregate_test.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, str::FromStr};
+use std::{collections::HashSet, str::FromStr, time::Duration};
 
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use tap_aggregator::{
@@ -36,6 +36,7 @@ async fn aggregation_test() {
         max_request_body_size,
         max_response_body_size,
         max_concurrent_connections,
+        Duration::from_secs(60),
         None,
     )
     .await

--- a/tap_aggregator/tests/aggregate_v1_and_v2.rs
+++ b/tap_aggregator/tests/aggregate_v1_and_v2.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
 use tap_aggregator::{
     grpc::{
@@ -40,6 +40,7 @@ async fn aggregation_test() {
         max_request_body_size,
         max_response_body_size,
         max_concurrent_connections,
+        Duration::from_secs(60),
         None,
     )
     .await

--- a/tap_core/Cargo.toml
+++ b/tap_core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tap_core"
 version = "6.0.2"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme = "README.md"

--- a/tap_core/src/manager/context/memory.rs
+++ b/tap_core/src/manager/context/memory.rs
@@ -216,12 +216,8 @@ impl InMemoryContext {
     pub fn increase_escrow(&mut self, sender_id: Address, value: u128) {
         let mut sender_escrow_storage = self.sender_escrow_storage.write().unwrap();
 
-        if let Some(current_value) = sender_escrow_storage.get(&sender_id) {
-            let mut sender_escrow_storage = self.sender_escrow_storage.write().unwrap();
-            sender_escrow_storage.insert(sender_id, current_value + value);
-        } else {
-            sender_escrow_storage.insert(sender_id, value);
-        }
+        let new_value = sender_escrow_storage.get(&sender_id).copied().unwrap_or(0) + value;
+        sender_escrow_storage.insert(sender_id, new_value);
     }
 
     pub fn reduce_escrow(&self, sender_id: Address, value: u128) -> Result<(), InMemoryError> {

--- a/tap_eip712_message/Cargo.toml
+++ b/tap_eip712_message/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tap_eip712_message"
 version = "0.2.3"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "EIP712 singed messages used by TAP"

--- a/tap_graph/Cargo.toml
+++ b/tap_graph/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tap_graph"
 version = "0.3.5"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "The Graph TAP receipt structs"

--- a/tap_integration_tests/Cargo.toml
+++ b/tap_integration_tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tap_integration_tests"
 version = "0.1.26"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 autotests = false

--- a/tap_integration_tests/tests/showcase.rs
+++ b/tap_integration_tests/tests/showcase.rs
@@ -10,6 +10,7 @@ use std::{
     net::{SocketAddr, TcpListener},
     str::FromStr,
     sync::{Arc, RwLock},
+    time::Duration,
 };
 
 use anyhow::{Error, Result};
@@ -861,6 +862,7 @@ async fn start_sender_aggregator(
         http_request_size_limit,
         http_response_size_limit,
         http_max_concurrent_connections,
+        Duration::from_secs(60),
         None,
     )
     .await?;

--- a/tap_receipt/Cargo.toml
+++ b/tap_receipt/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tap_receipt"
 version = "1.1.4"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "TAP Receipt states and checks"


### PR DESCRIPTION
This PR addresses three security findings from the TrustSec audit (Nov-Dec 2025) affecting the timeline-aggregation-protocol repository.

## Changes

### TRST-M-4: Missing HTTP Timeouts (Slowloris DoS Protection)

Added configurable request timeouts to prevent Slowloris-style DoS attacks:
- New `--request-timeout-secs` CLI argument (default: 60s, env: `TAP_REQUEST_TIMEOUT_SECS`)
- Add `TimeoutLayer` to both HTTP and gRPC endpoints
- Returns `408 Request Timeout` when exceeded

### TRST-L-6: Kafka Publication Failure Handling

When `tap-aggregator` creates a RAV but fails to publish it to Kafka, the system now:
- Tracks success/failure via Prometheus metrics (`kafka_publish_success_total`, `kafka_publish_failure_total`)
- Logs detailed error with context about potential escrow tracking drift
- Continues returning the RAV to the client (availability over consistency)

This approach was chosen after analyzing the downstream impact on `tap-escrow-manager` and the gateway. Blocking RAV creation on Kafka failures would punish indexers for gateway infrastructure issues, while the escrow manager has safety nets (receipts topic, manual `debts` override, on-chain balance observation).
 Updated `tap_aggregator/README.md` with a new Metrics section.

### TRST-L-7: Deadlock in `increase_escrow()`

Fixed a deadlock caused by attempting to acquire the same `RwLock` twice within `increase_escrow()`. This bug was introduced during migration from `tokio::sync::RwLock` to `std::sync::RwLock` where the duplicate lock acquisition pattern wasn't removed.


### Related

Audit Report: **TrustSec - The Graph Indexer*** (Horizon Upgrade)
Findings: **TRST-M-4**, **TRST-L-6**, **TRST-L-7**